### PR TITLE
Support offset references in Diagnostics Verifier

### DIFF
--- a/Tests/SemanticTests/events.flint
+++ b/Tests/SemanticTests/events.flint
@@ -12,11 +12,11 @@ EventTest :: (any) {
 
     eventA(true, false, c) // expected-error {{Cannot convert expression of type 'Bool' to expected argument type 'Int'}}
 
-    // expected-error@17 {{Cannot convert expression of type 'Bool' to expected argument type 'Int'}}
-    // expected-error@17 {{Cannot convert expression of type 'Int' to expected argument type 'Bool'}}
-    eventA(true, 3, c) 
 
-// expected-error@20 {{Function 'eventA' is not in scope or cannot be called using the caller capability 'any'}}
-    eventA(true)
+
+    eventA(true, 3, c) // expected-error {{Cannot convert expression of type 'Bool' to expected argument type 'Int'}}
+                       // expected-error@-1 {{Cannot convert expression of type 'Int' to expected argument type 'Bool'}}
+
+eventA(true) // expected-error {{Function 'eventA' is not in scope or cannot be called using the caller capability 'any'}}
   }
 }

--- a/Tests/SemanticTests/inits.flint
+++ b/Tests/SemanticTests/inits.flint
@@ -9,9 +9,8 @@ contract Test {
   var f: Int
   let g: Bool
   var x: B
-  var y: B = B(f, g) 
-  // expected-error@12 {{Cannot use state property 'f' within the initialization of another property}}
-  // expected-error@12 {{Cannot use state property 'g' within the initialization of another property}}
+  var y: B = B(f, g) // expected-error {{Cannot use state property 'f' within the initialization of another property}}
+                     // expected-error@-1 {{Cannot use state property 'g' within the initialization of another property}}
 }
 
 Test :: caller <- (any) {
@@ -19,8 +18,8 @@ Test :: caller <- (any) {
     self.a = a
     self.f = f
   } // expected-error {{Return from initializer without initializing all properties}}
-  // expected-note@8 {{'e' is uninitialized}}
-  // expected-note@11 {{'x' is uninitialized}}
+    // expected-note@8 {{'e' is uninitialized}}
+    // expected-note@11 {{'x' is uninitialized}}
 
   public init() { // expected-error {{A public initializer has already been defined}}
     self.a = caller

--- a/Tests/SemanticTests/invalid_function_call.flint
+++ b/Tests/SemanticTests/invalid_function_call.flint
@@ -11,8 +11,7 @@ Test :: caller <- (any) {
 
   public func foo() {
 
-// expected-error@15 {{Function 'bar' is not in scope or cannot be called using the caller capability 'any'}}
-    bar()
+    bar() // expected-error {{Function 'bar' is not in scope or cannot be called using the caller capability 'any'}}
   }
 }
 

--- a/Tests/SemanticTests/invalid_types.flint
+++ b/Tests/SemanticTests/invalid_types.flint
@@ -22,9 +22,8 @@ InvalidTypes :: (any) {
     var a: Bool = true
     a = b // expected-error {{Use of undeclared identifier 'b'}}
 
-    // expected-error@27 {{Incompatible assignment between values of type 'Address' and 'Bool'}}
-    // expected-error@27 {{Cannot convert expression of type 'Bool' to expected subscript type 'Int'}}
-    arr[a] = a
+    arr[a] = a // expected-error {{Incompatible assignment between values of type 'Address' and 'Bool'}}
+               // expected-error@-1 {{Cannot convert expression of type 'Bool' to expected subscript type 'Int'}}
 
     dict[3] // expected-error {{Cannot convert expression of type 'Int' to expected subscript type 'Address'}}
     dict[a] // expected-error {{Cannot convert expression of type 'Bool' to expected subscript type 'Address'}}

--- a/Tests/SemanticTests/multi_dim_array.flint
+++ b/Tests/SemanticTests/multi_dim_array.flint
@@ -19,7 +19,7 @@ MultiDimArray :: (any) {
   }
   public func value3(i: Int, j: String) -> Int {
     return dict[j][i] // expected-error {{Cannot convert expression of type 'Bool' to expected return type 'Int'}}
-                      // expected-error@21 {{Cannot convert expression of type 'String' to expected subscript type 'Int'}}
-                      // expected-error@21 {{Cannot convert expression of type 'Int' to expected subscript type 'String'}}
+                      // expected-error@-1 {{Cannot convert expression of type 'String' to expected subscript type 'Int'}}
+                      // expected-error@-2 {{Cannot convert expression of type 'Int' to expected subscript type 'String'}}
   }
 }

--- a/Tests/SemanticTests/no_associated_contract.flint
+++ b/Tests/SemanticTests/no_associated_contract.flint
@@ -2,11 +2,11 @@
 
 // expected-warning@0 {{No contract declaration in top level module}}
 
-// expected-error@6 {{Contract behavior declaration for 'Test' has no associated contract declaration}}
+// expected-error@+1 {{Contract behavior declaration for 'Test' has no associated contract declaration}}
 Test :: (any) {
   func foo(a: Int) {
 
-    // expected-error@10 {{Cannot convert expression of type 'Int' to expected return type 'Void'}}
+    // expected-error@+1 {{Cannot convert expression of type 'Int' to expected return type 'Void'}}
     return 3 * (1 + 2);
   }
 }

--- a/Tests/SemanticTests/undeclared_identifiers.flint
+++ b/Tests/SemanticTests/undeclared_identifiers.flint
@@ -9,6 +9,6 @@ Test :: caller <- (any) {
     var a: Int = 0
     a += 1
     b.foo() // expected-error {{Use of undeclared identifier 'b'}}
-    // expected-error@11 {{Function 'foo' is not in scope or cannot be called using the caller capability 'any'}}
+            // expected-error@-1 {{Function 'foo' is not in scope or cannot be called using the caller capability 'any'}}
   }
 }


### PR DESCRIPTION
Issue: #275 

# Implementation Overview
By supporting offset references we have a position agnostic error check
 ```swift
arr[a] = a // expected-error {{Incompatible assignment between values of type 'Address' and 'Bool'}}
            // expected-error@-1 {{Cannot convert expression of type 'Bool' to expected subscript type 'Int'}}
```
Also possible are:
```swift
// expected-error@+n {{Message}}
// expected-error@-n {{Message}}
```

# Notes
Currently we have diagnostics such as:
```swift
arr[a] = a // expected-error {{Incompatible assignment between values of type 'Address' and 'Bool'}}
           // expected-error@25 {{Cannot convert expression of type 'Bool' to expected subscript type 'Int'}}
```
This is highly dependent on the test cases staying static and hence the line having no line number changes. The error is always going to be referring to the line above it. 
# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Include tests
- [x] Add `review wanted` label, remove "WIP" in PR title
