### PR TITLE
Parse Type State restrictions.

### DIFF
--- a/Sources/AST/ASTDumper.swift
+++ b/Sources/AST/ASTDumper.swift
@@ -75,6 +75,11 @@ public class ASTDumper {
       if let capabilityBinding = contractBehaviorDeclaration.capabilityBinding {
         self.writeLine("capability binding \"\(capabilityBinding.name)\"")
       }
+      if let typeStates = contractBehaviorDeclaration.typeStates {
+        for typeState in typeStates {
+          self.dump(typeState)
+        }
+      }
       for callerCapability in contractBehaviorDeclaration.callerCapabilities {
         self.dump(callerCapability)
       }
@@ -264,6 +269,12 @@ public class ASTDumper {
     }
   }
 
+  func dump(_ typeState: TypeState) {
+    writeNode("TypeState") {
+      self.dump(typeState.identifier)
+    }
+  }
+
   func dump(_ expression: Expression) {
     writeNode("Expression") {
       switch expression {
@@ -295,7 +306,7 @@ public class ASTDumper {
       }
     }
   }
-  
+
   func dump(_ inoutExpression: InoutExpression) {
     writeNode("InoutExpression") {
       self.dump(inoutExpression.expression)
@@ -367,7 +378,7 @@ public class ASTDumper {
       }
     }
   }
-  
+
   func dump(_ token: Token) {
     writeLine("token: \(token.kind.description)")
   }
@@ -387,7 +398,7 @@ public class ASTDumper {
       self.dump(rangeExpression.bound)
     }
   }
-  
+
   func dump(_ dictionaryLiteral: DictionaryLiteral) {
     writeNode("DictionaryLiteral") {
       for element in dictionaryLiteral.elements {

--- a/Sources/AST/ASTPass.swift
+++ b/Sources/AST/ASTPass.swift
@@ -26,6 +26,7 @@ public protocol ASTPass {
   func process(identifier: Identifier, passContext: ASTPassContext) -> ASTPassResult<Identifier>
   func process(type: Type, passContext: ASTPassContext) -> ASTPassResult<Type>
   func process(callerCapability: CallerCapability, passContext: ASTPassContext) -> ASTPassResult<CallerCapability>
+  func process(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState>
   func process(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression>
   func process(statement: Statement, passContext: ASTPassContext) -> ASTPassResult<Statement>
   func process(inoutExpression: InoutExpression, passContext: ASTPassContext) -> ASTPassResult<InoutExpression>
@@ -56,6 +57,7 @@ public protocol ASTPass {
   func postProcess(identifier: Identifier, passContext: ASTPassContext) -> ASTPassResult<Identifier>
   func postProcess(type: Type, passContext: ASTPassContext) -> ASTPassResult<Type>
   func postProcess(callerCapability: CallerCapability, passContext: ASTPassContext) -> ASTPassResult<CallerCapability>
+  func postProcess(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState>
   func postProcess(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression>
   func postProcess(statement: Statement, passContext: ASTPassContext) -> ASTPassResult<Statement>
   func postProcess(inoutExpression: InoutExpression, passContext: ASTPassContext) -> ASTPassResult<InoutExpression>
@@ -142,6 +144,10 @@ public struct AnyASTPass: ASTPass {
     return base.process(callerCapability: callerCapability, passContext: passContext)
   }
 
+  public func process(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
+    return base.process(typeState: typeState, passContext: passContext)
+  }
+
   public func process(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
     return base.process(expression: expression, passContext: passContext)
   }
@@ -149,7 +155,7 @@ public struct AnyASTPass: ASTPass {
   public func process(statement: Statement, passContext: ASTPassContext) -> ASTPassResult<Statement> {
     return base.process(statement: statement, passContext: passContext)
   }
-  
+
   public func process(inoutExpression: InoutExpression, passContext: ASTPassContext) -> ASTPassResult<InoutExpression> {
     return base.process(inoutExpression: inoutExpression, passContext: passContext)
   }
@@ -165,7 +171,7 @@ public struct AnyASTPass: ASTPass {
   public func process(arrayLiteral: ArrayLiteral, passContext: ASTPassContext) -> ASTPassResult<ArrayLiteral> {
     return base.process(arrayLiteral: arrayLiteral, passContext: passContext)
   }
-  
+
   public func process(rangeExpression: RangeExpression, passContext: ASTPassContext) -> ASTPassResult<RangeExpression> {
     return base.process(rangeExpression: rangeExpression, passContext: passContext)
   }
@@ -194,7 +200,7 @@ public struct AnyASTPass: ASTPass {
   public func process(forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement> {
     return base.process(forStatement: forStatement, passContext: passContext)
   }
-  
+
   public func postProcess(topLevelModule: TopLevelModule, passContext: ASTPassContext) -> ASTPassResult<TopLevelModule> {
     return base.postProcess(topLevelModule: topLevelModule, passContext: passContext)
   }
@@ -259,6 +265,10 @@ public struct AnyASTPass: ASTPass {
     return base.postProcess(callerCapability: callerCapability, passContext: passContext)
   }
 
+  public func postProcess(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
+    return base.postProcess(typeState: typeState, passContext: passContext)
+  }
+
   public func postProcess(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
     return base.postProcess(expression: expression, passContext: passContext)
   }
@@ -266,7 +276,7 @@ public struct AnyASTPass: ASTPass {
   public func postProcess(statement: Statement, passContext: ASTPassContext) -> ASTPassResult<Statement> {
     return base.postProcess(statement: statement, passContext: passContext)
   }
-  
+
   public func postProcess(inoutExpression: InoutExpression, passContext: ASTPassContext) -> ASTPassResult<InoutExpression> {
     return base.postProcess(inoutExpression: inoutExpression, passContext: passContext)
   }
@@ -282,11 +292,11 @@ public struct AnyASTPass: ASTPass {
   public func postProcess(arrayLiteral: ArrayLiteral, passContext: ASTPassContext) -> ASTPassResult<ArrayLiteral> {
     return base.postProcess(arrayLiteral: arrayLiteral, passContext: passContext)
   }
-  
+
   public func postProcess(rangeExpression: RangeExpression, passContext: ASTPassContext) -> ASTPassResult<RangeExpression> {
     return base.postProcess(rangeExpression: rangeExpression, passContext: passContext)
   }
-  
+
   public func postProcess(dictionaryLiteral: DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<DictionaryLiteral> {
     return base.postProcess(dictionaryLiteral: dictionaryLiteral, passContext: passContext)
   }
@@ -306,7 +316,7 @@ public struct AnyASTPass: ASTPass {
   public func postProcess(ifStatement: IfStatement, passContext: ASTPassContext) -> ASTPassResult<IfStatement> {
     return base.postProcess(ifStatement: ifStatement, passContext: passContext)
   }
-  
+
   public func postProcess(forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement> {
     return base.postProcess(forStatement: forStatement, passContext: passContext)
   }

--- a/Sources/AST/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor.swift
@@ -37,7 +37,7 @@ public struct ASTVisitor<Pass: ASTPass> {
 
   func visit(_ topLevelDeclaration: TopLevelDeclaration, passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration> {
     var processResult = pass.process(topLevelDeclaration: topLevelDeclaration, passContext: passContext)
-    
+
     switch processResult.element {
     case .contractBehaviorDeclaration(let contractBehaviorDeclaration):
 
@@ -86,6 +86,12 @@ public struct ASTVisitor<Pass: ASTPass> {
     var processResult = pass.process(contractBehaviorDeclaration: contractBehaviorDeclaration, passContext: passContext)
 
     processResult.element.contractIdentifier = processResult.combining(visit(processResult.element.contractIdentifier, passContext: processResult.passContext))
+
+    if let typeStates = processResult.element.typeStates {
+      processResult.element.typeStates = typeStates.map { typeState in
+        return processResult.combining(visit(typeState, passContext: processResult.passContext))
+      }
+    }
 
     if let capabilityBinding = processResult.element.capabilityBinding {
       processResult.element.capabilityBinding = processResult.combining(visit(capabilityBinding, passContext: processResult.passContext))
@@ -169,7 +175,7 @@ public struct ASTVisitor<Pass: ASTPass> {
 
     processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
     processResult.element.type = processResult.combining(visit(processResult.element.type, passContext: processResult.passContext))
-    
+
     if let assignedExpression = processResult.element.assignedExpression {
       let previousScopeContext = processResult.passContext.scopeContext
       // Create an empty scope context.
@@ -293,6 +299,15 @@ public struct ASTVisitor<Pass: ASTPass> {
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }
 
+  func visit(_ typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
+    var processResult = pass.process(typeState: typeState, passContext: passContext)
+
+    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+
+    let postProcessResult = pass.postProcess(typeState: processResult.element, passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+  }
+
   func visit(_ expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
     var processResult = pass.process(expression: expression, passContext: passContext)
 
@@ -349,11 +364,11 @@ public struct ASTVisitor<Pass: ASTPass> {
     let postProcessResult = pass.postProcess(statement: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }
-  
+
   func visit(_ inoutExpression: InoutExpression, passContext: ASTPassContext) -> ASTPassResult<InoutExpression> {
     var processResult = pass.process(inoutExpression: inoutExpression, passContext: passContext)
     processResult.element.expression = processResult.combining(visit(processResult.element.expression, passContext: processResult.passContext))
-    
+
     let postProcessResult = pass.postProcess(inoutExpression: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }
@@ -388,7 +403,7 @@ public struct ASTVisitor<Pass: ASTPass> {
     processResult.passContext.isFunctionCall = false
 
     processResult.element.arguments = processResult.element.arguments.map { argument in
-      
+
       let x = visit(argument, passContext: processResult.passContext)
       return processResult.combining(x)
     }
@@ -414,11 +429,11 @@ public struct ASTVisitor<Pass: ASTPass> {
     var element = processResult.element
     element.initial = processResult.combining(visit(element.initial, passContext: processResult.passContext))
     element.bound = processResult.combining(visit(element.bound, passContext: processResult.passContext))
-    
+
     let postProcessResult = pass.postProcess(rangeExpression: element, passContext: processResult.passContext)
     return ASTPassResult(element: element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }
-  
+
   func visit(_ dictionaryLiteral: DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<DictionaryLiteral> {
     var processResult = pass.process(dictionaryLiteral: dictionaryLiteral, passContext: passContext)
 
@@ -471,31 +486,31 @@ public struct ASTVisitor<Pass: ASTPass> {
     processResult.element.body = processResult.element.body.map { statement in
       return processResult.combining(visit(statement, passContext: processResult.passContext))
     }
-    
+
     if processResult.element.ifBodyScopeContext == nil {
       processResult.element.ifBodyScopeContext = processResult.passContext.scopeContext
     }
-    
+
     processResult.passContext.scopeContext = scopeContext
 
     processResult.element.elseBody = processResult.element.elseBody.map { statement in
       return processResult.combining(visit(statement, passContext: processResult.passContext))
     }
-    
+
     if processResult.element.elseBodyScopeContext == nil {
       processResult.element.elseBodyScopeContext = processResult.passContext.scopeContext
     }
-    
+
     processResult.passContext.scopeContext = scopeContext
 
     let postProcessResult = pass.postProcess(ifStatement: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }
-  
+
   func visit(_ forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement> {
     var passContext = passContext
     var processResult = pass.process(forStatement: forStatement, passContext: passContext)
-    
+
     processResult.element.variable = processResult.combining(visit(processResult.element.variable, passContext: processResult.passContext))
     processResult.element.iterable = processResult.combining(visit(processResult.element.iterable, passContext: processResult.passContext))
 
@@ -503,13 +518,13 @@ public struct ASTVisitor<Pass: ASTPass> {
     processResult.element.body = processResult.element.body.map { statement in
       return processResult.combining(visit(statement, passContext: processResult.passContext))
     }
- 
+
     if processResult.element.forBodyScopeContext == nil {
       processResult.element.forBodyScopeContext = processResult.passContext.scopeContext
     }
-    
+
     processResult.passContext.scopeContext = scopeContext
-    
+
     let postProcessResult = pass.postProcess(forStatement: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }

--- a/Sources/AST/Environment.swift
+++ b/Sources/AST/Environment.swift
@@ -291,16 +291,16 @@ public struct Environment {
   public func type(ofRangeExpression rangeExpression: RangeExpression, enclosingType: RawTypeIdentifier, scopeContext: ScopeContext) -> Type.RawType {
     let elementType = type(of: rangeExpression.initial, enclosingType: enclosingType, scopeContext: scopeContext)
     let boundType   = type(of: rangeExpression.bound, enclosingType: enclosingType, scopeContext: scopeContext)
-    
+
     if elementType != boundType {
       // The bounds have different types.
       return .errorType
     }
-    
+
     return .rangeType(elementType)
   }
 
-  
+
   // The type of a dictionary literal.
   public func type(ofDictionaryLiteral dictionaryLiteral: DictionaryLiteral, enclosingType: RawTypeIdentifier, scopeContext: ScopeContext) -> Type.RawType {
     var keyType: Type.RawType?
@@ -484,7 +484,7 @@ public struct Environment {
   func areCallerCapabilitiesCompatible(source: [CallerCapability], target: [CallerCapability]) -> Bool {
     guard !target.isEmpty else { return true }
     for callCallerCapability in source {
-      if !target.contains(where: { return callCallerCapability.isSubcapability(callerCapability: $0) }) {
+      if !target.contains(where: { return callCallerCapability.isSubCapability(of: $0) }) {
         return false
       }
     }
@@ -525,10 +525,10 @@ public struct Environment {
 
   /// The memory offset of a property in a type.
   public func propertyOffset(for property: String, enclosingType: RawTypeIdentifier) -> Int? {
-    
+
     var offsetMap = [String: Int]()
     var offset = 0
-    
+
     let properties = types[enclosingType]!.orderedProperties.prefix(while: { $0 != property })
 
     for p in properties {

--- a/Sources/AST/Token.swift
+++ b/Sources/AST/Token.swift
@@ -30,6 +30,7 @@ extension Token {
       case doubleColon        = "::"
       case openBracket        = "("
       case closeBracket       = ")"
+      case at                 = "@"
       case arrow              = "->"
       case leftArrow          = "<-"
       case comma              = ","
@@ -57,11 +58,11 @@ extension Token {
       case minusEqual = "-="
       case timesEqual = "*="
       case divideEqual = "/="
-      
+
       // Ranges
       case halfOpenRange = "..<"
       case closedRange = "..."
-      
+
       // Comparisons
       case doubleEqual = "=="
       case notEqual = "!="

--- a/Sources/IRGen/IULIAPreprocessor.swift
+++ b/Sources/IRGen/IULIAPreprocessor.swift
@@ -151,6 +151,10 @@ public struct IULIAPreprocessor: ASTPass {
     return ASTPassResult(element: callerCapability, diagnostics: [], passContext: passContext)
   }
 
+  public func process(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
+    return ASTPassResult(element: typeState, diagnostics: [], passContext: passContext)
+  }
+
   public func process(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
     var expression = expression
     let environment = passContext.environment!
@@ -375,7 +379,7 @@ public struct IULIAPreprocessor: ASTPass {
   public func process(rangeExpression: AST.RangeExpression, passContext: ASTPassContext) -> ASTPassResult<AST.RangeExpression> {
     return ASTPassResult(element: rangeExpression, diagnostics: [], passContext: passContext)
   }
-  
+
   public func process(dictionaryLiteral: AST.DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<AST.DictionaryLiteral> {
     return ASTPassResult(element: dictionaryLiteral, diagnostics: [], passContext: passContext)
   }
@@ -395,7 +399,7 @@ public struct IULIAPreprocessor: ASTPass {
   public func process(ifStatement: IfStatement, passContext: ASTPassContext) -> ASTPassResult<IfStatement> {
     return ASTPassResult(element: ifStatement, diagnostics: [], passContext: passContext)
   }
-  
+
   public func process(forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement> {
     return ASTPassResult(element: forStatement, diagnostics: [], passContext: passContext)
   }
@@ -464,6 +468,10 @@ public struct IULIAPreprocessor: ASTPass {
     return ASTPassResult(element: callerCapability, diagnostics: [], passContext: passContext)
   }
 
+  public func postProcess(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
+    return ASTPassResult(element: typeState, diagnostics: [], passContext: passContext)
+  }
+
   public func postProcess(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
     return ASTPassResult(element: expression, diagnostics: [], passContext: passContext)
   }
@@ -484,7 +492,7 @@ public struct IULIAPreprocessor: ASTPass {
   public func postProcess(functionCall: FunctionCall, passContext: ASTPassContext) -> ASTPassResult<FunctionCall> {
     return ASTPassResult(element: functionCall, diagnostics: [], passContext: passContext)
   }
-  
+
   public func postProcess(rangeExpression: AST.RangeExpression, passContext: ASTPassContext) -> ASTPassResult<AST.RangeExpression> {
     return ASTPassResult(element: rangeExpression, diagnostics: [], passContext: passContext)
   }

--- a/Sources/Optimizer/Optimizer.swift
+++ b/Sources/Optimizer/Optimizer.swift
@@ -75,6 +75,10 @@ public struct Optimizer: ASTPass {
     return ASTPassResult(element: callerCapability, diagnostics: [], passContext: passContext)
   }
 
+  public func process(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
+    return ASTPassResult(element: typeState, diagnostics: [], passContext: passContext)
+  }
+
   public func process(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
     return ASTPassResult(element: expression, diagnostics: [], passContext: passContext)
   }
@@ -82,7 +86,7 @@ public struct Optimizer: ASTPass {
   public func process(statement: Statement, passContext: ASTPassContext) -> ASTPassResult<Statement> {
     return ASTPassResult(element: statement, diagnostics: [], passContext: passContext)
   }
-  
+
   public func process(inoutExpression: InoutExpression, passContext: ASTPassContext) -> ASTPassResult<InoutExpression> {
     return ASTPassResult(element: inoutExpression, diagnostics: [], passContext: passContext)
   }
@@ -98,7 +102,7 @@ public struct Optimizer: ASTPass {
   public func process(arrayLiteral: ArrayLiteral, passContext: ASTPassContext) -> ASTPassResult<ArrayLiteral> {
     return ASTPassResult(element: arrayLiteral, diagnostics: [], passContext: passContext)
   }
-  
+
   public func process(rangeExpression: AST.RangeExpression, passContext: ASTPassContext) -> ASTPassResult<AST.RangeExpression> {
     return ASTPassResult(element: rangeExpression, diagnostics: [], passContext: passContext)
   }
@@ -126,7 +130,7 @@ public struct Optimizer: ASTPass {
   public func process(forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement> {
     return ASTPassResult(element: forStatement, diagnostics: [], passContext: passContext)
   }
-  
+
   public func postProcess(topLevelModule: TopLevelModule, passContext: ASTPassContext) -> ASTPassResult<TopLevelModule> {
     return ASTPassResult(element: topLevelModule, diagnostics: [], passContext: passContext)
   }
@@ -191,6 +195,10 @@ public struct Optimizer: ASTPass {
     return ASTPassResult(element: callerCapability, diagnostics: [], passContext: passContext)
   }
 
+  public func postProcess(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
+    return ASTPassResult(element: typeState, diagnostics: [], passContext: passContext)
+  }
+
   public func postProcess(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
     return ASTPassResult(element: expression, diagnostics: [], passContext: passContext)
   }
@@ -214,7 +222,7 @@ public struct Optimizer: ASTPass {
   public func postProcess(arrayLiteral: ArrayLiteral, passContext: ASTPassContext) -> ASTPassResult<ArrayLiteral> {
     return ASTPassResult(element: arrayLiteral, diagnostics: [], passContext: passContext)
   }
-  
+
   public func postProcess(rangeExpression: AST.RangeExpression, passContext: ASTPassContext) -> ASTPassResult<AST.RangeExpression> {
     return ASTPassResult(element: rangeExpression, diagnostics: [], passContext: passContext)
   }
@@ -238,7 +246,7 @@ public struct Optimizer: ASTPass {
   public func postProcess(ifStatement: IfStatement, passContext: ASTPassContext) -> ASTPassResult<IfStatement> {
     return ASTPassResult(element: ifStatement, diagnostics: [], passContext: passContext)
   }
-  
+
   public func postProcess(forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement> {
     return ASTPassResult(element: forStatement, diagnostics: [], passContext: passContext)
   }

--- a/Sources/Parser/Tokenizer.swift
+++ b/Sources/Parser/Tokenizer.swift
@@ -124,6 +124,7 @@ public struct Tokenizer {
     "::": .punctuation(.doubleColon),
     "(": .punctuation(.openBracket),
     ")": .punctuation(.closeBracket),
+    "@": .punctuation(.at),
     "->": .punctuation(.arrow),
     "<-": .punctuation(.leftArrow),
     ",": .punctuation(.comma),
@@ -192,12 +193,13 @@ public struct Tokenizer {
           continue
         }
 
-        // The character is a newline.
+        // Add the new character directly to the components.
         components.append((String(char), sourceLocation(line: line, column: column, length: 1)))
       }
 
       column += 1
 
+      // The character is a newline.
       if CharacterSet.newlines.contains(char.unicodeScalars.first!) {
         line += 1
         column = 1
@@ -227,7 +229,7 @@ public struct Tokenizer {
     let stripped = component.replacingOccurrences(of: "_", with: "")
     return Int(stripped)
   }
-  
+
   /// Creates a source location for the current file.
   func sourceLocation(line: Int, column: Int, length: Int) -> SourceLocation {
     return SourceLocation(line: line, column: column, length: length, file: sourceFile, isFromStdlib: isFromStdlib)

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
@@ -333,6 +333,12 @@ public struct SemanticAnalyzer: ASTPass {
     return ASTPassResult(element: callerCapability, diagnostics: diagnostics, passContext: passContext)
   }
 
+  public func process(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
+    // TODO: Check that type state exists, etc.
+
+    return ASTPassResult(element: typeState, diagnostics: [], passContext: passContext)
+  }
+
   public func process(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
     return ASTPassResult(element: expression, diagnostics: [], passContext: passContext)
   }
@@ -369,7 +375,7 @@ public struct SemanticAnalyzer: ASTPass {
 
   public func process(rangeExpression: AST.RangeExpression, passContext: ASTPassContext) -> ASTPassResult<AST.RangeExpression> {
     var diagnostics = [Diagnostic]()
-    
+
     if case .literal(let startToken) = rangeExpression.initial,
        case .literal(let endToken) = rangeExpression.bound {
       if startToken.kind == endToken.kind, rangeExpression.op.kind == .punctuation(.halfOpenRange) {
@@ -381,7 +387,7 @@ public struct SemanticAnalyzer: ASTPass {
 
     return ASTPassResult(element: rangeExpression, diagnostics: diagnostics, passContext: passContext)
   }
-  
+
   public func process(dictionaryLiteral: AST.DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<AST.DictionaryLiteral> {
     return ASTPassResult(element: dictionaryLiteral, diagnostics: [], passContext: passContext)
   }
@@ -543,6 +549,10 @@ public struct SemanticAnalyzer: ASTPass {
     return ASTPassResult(element: callerCapability, diagnostics: [], passContext: passContext)
   }
 
+  public func postProcess(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
+    return ASTPassResult(element: typeState, diagnostics: [], passContext: passContext)
+  }
+
   public func postProcess(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
     return ASTPassResult(element: expression, diagnostics: [], passContext: passContext)
   }
@@ -628,7 +638,7 @@ public struct SemanticAnalyzer: ASTPass {
   public func postProcess(rangeExpression: AST.RangeExpression, passContext: ASTPassContext) -> ASTPassResult<AST.RangeExpression> {
     return ASTPassResult(element: rangeExpression, diagnostics: [], passContext: passContext)
   }
-  
+
   public func postProcess(dictionaryLiteral: AST.DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<AST.DictionaryLiteral> {
     return ASTPassResult(element: dictionaryLiteral, diagnostics: [], passContext: passContext)
   }
@@ -648,7 +658,7 @@ public struct SemanticAnalyzer: ASTPass {
   public func postProcess(ifStatement: IfStatement, passContext: ASTPassContext) -> ASTPassResult<IfStatement> {
     return ASTPassResult(element: ifStatement, diagnostics: [], passContext: passContext)
   }
-  
+
   public func postProcess(forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement> {
     return ASTPassResult(element: forStatement, diagnostics: [], passContext: passContext)
   }

--- a/Sources/SemanticAnalyzer/TypeChecker.swift
+++ b/Sources/SemanticAnalyzer/TypeChecker.swift
@@ -76,7 +76,7 @@ public struct TypeChecker: ASTPass {
   public func process(functionDeclaration: FunctionDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
     return ASTPassResult(element: functionDeclaration, diagnostics: [], passContext: passContext)
   }
-  
+
   public func process(initializerDeclaration: InitializerDeclaration, passContext: ASTPassContext) -> ASTPassResult<InitializerDeclaration> {
     return ASTPassResult(element: initializerDeclaration, diagnostics: [], passContext: passContext)
   }
@@ -103,6 +103,10 @@ public struct TypeChecker: ASTPass {
 
   public func process(callerCapability: CallerCapability, passContext: ASTPassContext) -> ASTPassResult<CallerCapability> {
     return ASTPassResult(element: callerCapability, diagnostics: [], passContext: passContext)
+  }
+
+  public func process(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
+    return ASTPassResult(element: typeState, diagnostics: [], passContext: passContext)
   }
 
   public func process(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
@@ -175,7 +179,7 @@ public struct TypeChecker: ASTPass {
   public func process(rangeExpression: AST.RangeExpression, passContext: ASTPassContext) -> ASTPassResult<AST.RangeExpression> {
     return ASTPassResult(element: rangeExpression, diagnostics: [], passContext: passContext)
   }
-  
+
   public func process(dictionaryLiteral: AST.DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<AST.DictionaryLiteral> {
     return ASTPassResult(element: dictionaryLiteral, diagnostics: [], passContext: passContext)
   }
@@ -189,19 +193,19 @@ public struct TypeChecker: ASTPass {
     let environment = passContext.environment!
     let typeIdentifier = passContext.enclosingTypeIdentifier!
     let scopeContext = passContext.scopeContext!
-    
+
     let identifierType = environment.type(of: subscriptExpression.baseExpression, enclosingType: typeIdentifier.name, scopeContext: scopeContext)
-    
+
     let actualType = environment.type(of: subscriptExpression.indexExpression, enclosingType: typeIdentifier.name, scopeContext: scopeContext)
     var expectedType: Type.RawType = .errorType
-    
+
     switch identifierType {
     case .arrayType (_), .fixedSizeArrayType(_): expectedType = .basicType(.int)
     case .dictionaryType(let keyType, _): expectedType = keyType
     default:
       diagnostics.append(.incompatibleSubscript(actualType: identifierType, expression: subscriptExpression.baseExpression))
     }
-    
+
     if !actualType.isCompatible(with: expectedType), ![actualType, expectedType].contains(.errorType) {
       diagnostics.append(.incompatibleSubscriptIndex(actualType: actualType, expectedType: expectedType, expression: .subscriptExpression(subscriptExpression)))
     }
@@ -236,10 +240,10 @@ public struct TypeChecker: ASTPass {
     var diagnostics = [Diagnostic]()
     let typeIdentifier = passContext.enclosingTypeIdentifier!
     let environment = passContext.environment!
-    
+
     let varType = environment.type(of: .variableDeclaration(forStatement.variable), enclosingType: typeIdentifier.name, scopeContext: passContext.scopeContext!)
     let iterableType = environment.type(of: forStatement.iterable, enclosingType: typeIdentifier.name, scopeContext: passContext.scopeContext!)
-    
+
     let valueType: Type.RawType;
     switch iterableType {
       case .arrayType(let v): valueType = v
@@ -250,18 +254,18 @@ public struct TypeChecker: ASTPass {
         diagnostics.append(.incompatibleForIterableType(iterableType: iterableType, statement: .forStatement(forStatement)))
         valueType = .errorType
     }
-    
+
     if case .range(_) = forStatement.iterable, valueType != .basicType(.int) {
       diagnostics.append(.incompatibleForIterableType(iterableType: iterableType, statement: .forStatement(forStatement)))
     }
-    
+
     if !varType.isCompatible(with: valueType), ![varType, valueType].contains(.errorType){
       diagnostics.append(.incompatibleForVariableType(varType: varType, valueType: valueType, statement: .forStatement(forStatement)))
     }
-    
+
     return ASTPassResult(element: forStatement, diagnostics: diagnostics, passContext: passContext)
   }
-  
+
   public func postProcess(topLevelModule: TopLevelModule, passContext: ASTPassContext) -> ASTPassResult<TopLevelModule> {
     return ASTPassResult(element: topLevelModule, diagnostics: [], passContext: passContext)
   }
@@ -297,7 +301,7 @@ public struct TypeChecker: ASTPass {
   public func postProcess(functionDeclaration: FunctionDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
     return ASTPassResult(element: functionDeclaration, diagnostics: [], passContext: passContext)
   }
-  
+
   public func postProcess(initializerDeclaration: InitializerDeclaration, passContext: ASTPassContext) -> ASTPassResult<InitializerDeclaration> {
     return ASTPassResult(element: initializerDeclaration, diagnostics: [], passContext: passContext)
   }
@@ -326,6 +330,10 @@ public struct TypeChecker: ASTPass {
     return ASTPassResult(element: callerCapability, diagnostics: [], passContext: passContext)
   }
 
+  public func postProcess(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
+    return ASTPassResult(element: typeState, diagnostics: [], passContext: passContext)
+  }
+
   public func postProcess(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
     return ASTPassResult(element: expression, diagnostics: [], passContext: passContext)
   }
@@ -333,7 +341,7 @@ public struct TypeChecker: ASTPass {
   public func postProcess(statement: Statement, passContext: ASTPassContext) -> ASTPassResult<Statement> {
     return ASTPassResult(element: statement, diagnostics: [], passContext: passContext)
   }
-  
+
   public func postProcess(inoutExpression: InoutExpression, passContext: ASTPassContext) -> ASTPassResult<InoutExpression> {
     return ASTPassResult(element: inoutExpression, diagnostics: [], passContext: passContext)
   }
@@ -349,7 +357,7 @@ public struct TypeChecker: ASTPass {
   public func postProcess(arrayLiteral: ArrayLiteral, passContext: ASTPassContext) -> ASTPassResult<ArrayLiteral> {
     return ASTPassResult(element: arrayLiteral, diagnostics: [], passContext: passContext)
   }
-  
+
   public func postProcess(rangeExpression: AST.RangeExpression, passContext: ASTPassContext) -> ASTPassResult<AST.RangeExpression> {
     return ASTPassResult(element: rangeExpression, diagnostics: [], passContext: passContext)
   }
@@ -373,7 +381,7 @@ public struct TypeChecker: ASTPass {
   public func postProcess(ifStatement: IfStatement, passContext: ASTPassContext) -> ASTPassResult<IfStatement> {
     return ASTPassResult(element: ifStatement, diagnostics: [], passContext: passContext)
   }
-  
+
   public func postProcess(forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement> {
     return ASTPassResult(element: forStatement, diagnostics: [], passContext: passContext)
   }

--- a/Tests/ParserTests/type_states.flint
+++ b/Tests/ParserTests/type_states.flint
@@ -1,0 +1,16 @@
+// RUN: %flintc %s --dump-ast | %FileCheck %s --prefix CHECK-AST
+
+contract CapabilityBinding {}
+
+// CHECK-AST: ContractBehaviorDeclaration
+// CHECK-AST:   identifier "CapabilityBinding"
+// CHECK-AST:   TypeState
+// CHECK-AST:     identifier "stated"
+// CHECK-AST:   CallerCapability
+// CHECK-AST:     identifier "any"
+CapabilityBinding @(stated) :: (any) {
+
+// CHECK-AST: InitializerDeclaration
+// CHECK-AST:   public
+  public init() {}
+}


### PR DESCRIPTION
Issue: #273

# Implementation Overview

Adds parsing and AST representations for Type States, in the standard way. This broadly follows the approach used by Caller Capabilities, although once enums are merged I imagine that it will need a bit of fixing so they conform.

# Notes

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Include tests
- [x] ~Add `review wanted` label~, remove "WIP" in PR title
