### PR TITLE
Check operand types are compatible with operators

### DIFF
--- a/Sources/AST/Environment.swift
+++ b/Sources/AST/Environment.swift
@@ -385,7 +385,7 @@ public struct Environment {
     switch expression {
     case .inoutExpression(let inoutExpression):
       return .inoutType(type(of: inoutExpression.expression, enclosingType: enclosingType, typeStates: typeStates, callerCapabilities: callerCapabilities, scopeContext: scopeContext))
-      
+
     case .binaryExpression(let binaryExpression):
       if binaryExpression.opToken.isBooleanOperator {
         return .basicType(.bool)
@@ -401,8 +401,9 @@ public struct Environment {
           break
         }
       }
+
       return type(of: binaryExpression.rhs, enclosingType: enclosingType, typeStates: typeStates, callerCapabilities: callerCapabilities, scopeContext: scopeContext)
-      
+
      case .bracketedExpression(let bracketedExpression):
       return type(of: bracketedExpression.expression, enclosingType: enclosingType, typeStates: typeStates, callerCapabilities: callerCapabilities, scopeContext: scopeContext)
 

--- a/Sources/SemanticAnalyzer/TypeError.swift
+++ b/Sources/SemanticAnalyzer/TypeError.swift
@@ -28,6 +28,17 @@ extension Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Incompatible assignment between values of type '\(lhsType.name)' and '\(rhsType.name)'")
   }
 
+  static func incompatibleOperandTypes(operatorKind: Token.Kind.Punctuation, lhsType: Type.RawType, rhsType: Type.RawType, expectedTypes: [Type.RawType], expression: Expression) -> Diagnostic {
+    let notes = expectedTypes.map { expectedType in
+      return Diagnostic(severity: .note, sourceLocation: expression.sourceLocation, message: "Expected operands to be of type \(expectedType.name)")
+    }
+    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Incompatible use of operator '\(operatorKind.rawValue)' on values of types '\(lhsType.name)' and '\(rhsType.name)'", notes: notes)
+  }
+
+  static func unmatchedOperandTypes(operatorKind: Token.Kind.Punctuation, lhsType: Type.RawType, rhsType: Type.RawType, expression: Expression) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Incompatible use of operator '\(operatorKind.rawValue)' on values of unmatched types '\(lhsType.name)' and '\(rhsType.name)'")
+  }
+
   static func incompatibleArgumentType(actualType: Type.RawType, expectedType: Type.RawType, expression: Expression) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Cannot convert expression of type '\(actualType.name)' to expected argument type '\(expectedType.name)'")
   }

--- a/Tests/ParserTests/for.flint
+++ b/Tests/ParserTests/for.flint
@@ -1,24 +1,24 @@
 // RUN: %flintc %s --dump-ast | %FileCheck %s --prefix CHECK-AST
 
 contract Foo {
-  var arr: [Address] = []
+  var arr: [Int] = []
 }
 
 Foo :: (any) {
   public init() {}
 
-  func foo() -> Address {
-    var largest: Address
+  func foo() -> Int {
+    var largest: Int
     var max: Int
     // CHECK-AST: ForStatement
 
     // CHECK-AST:   token: var
     // CHECK-AST:   identifier "x"
-    // CHECK-AST:   type Address
+    // CHECK-AST:   type Int
 
     // CHECK-AST:   identifier "arr"
 
-    for var x: Address in arr {
+    for var x: Int in arr {
       if(x > largest){
         largest = x
       }

--- a/Tests/SemanticTests/enums.flint
+++ b/Tests/SemanticTests/enums.flint
@@ -66,10 +66,12 @@ Test :: (any) {
 
   public func type1() -> Int {
     return D.a + D.c // expected-error {{Cannot convert expression of type 'D' to expected return type 'Int'}}
+    // expected-error@-1 {{Incompatible use of operator '+' on values of types 'D' and 'D'}}
   }
 
   public func type1a() -> Int {
     return D.a + E.a // expected-error {{Cannot convert expression of type 'E' to expected return type 'Int'}}
+    // expected-error@-1 {{Incompatible use of operator '+' on values of types 'D' and 'E'}}
   }
 
 // Binary operations aren't type checked...
@@ -106,4 +108,3 @@ Test :: (any) {
     return integer // expected-error {{Cannot convert expression of type 'Int' to expected return type 'D'}}
   }
 }
-

--- a/Tests/SemanticTests/operand_types.flint
+++ b/Tests/SemanticTests/operand_types.flint
@@ -1,0 +1,27 @@
+// RUN: %flintc %s --verify
+
+contract Test {
+  var a: Int = 0
+  var b: Bool = false
+  var c: Address = 0x0000000000000000000000000000000000000000
+  var d: D = D()
+}
+
+Test :: (any) {
+  public init() {
+    a = 1
+    a = false // expected-error {{Incompatible assignment between values of type 'Int' and 'Bool'}}
+    a = b // expected-error {{Incompatible assignment between values of type 'Int' and 'Bool'}}
+    a = c // expected-error {{Incompatible assignment between values of type 'Int' and 'Address'}}
+    a = d // expected-error {{Incompatible assignment between values of type 'Int' and 'D'}}
+    d = 0 // expected-error {{Incompatible assignment between values of type 'D' and 'Int'}}
+    (a < 1)
+    (a < b) // expected-error {{Incompatible use of operator '<' on values of types 'Int' and 'Bool'}}
+    (a > c) // expected-error {{Incompatible use of operator '>' on values of types 'Int' and 'Address'}}
+    (a == d) // expected-error {{Incompatible use of operator '==' on values of unmatched types 'Int' and 'D'}}
+    (a == b) // expected-error {{Incompatible use of operator '==' on values of unmatched types 'Int' and 'Bool'}}
+    (d != d) // expected-error {{Incompatible use of operator '!=' on values of types 'D' and 'D'}}
+  }
+}
+
+struct D { }

--- a/Tests/SemanticTests/operand_types.flint
+++ b/Tests/SemanticTests/operand_types.flint
@@ -15,12 +15,12 @@ Test :: (any) {
     a = c // expected-error {{Incompatible assignment between values of type 'Int' and 'Address'}}
     a = d // expected-error {{Incompatible assignment between values of type 'Int' and 'D'}}
     d = 0 // expected-error {{Incompatible assignment between values of type 'D' and 'Int'}}
-    (a < 1)
-    (a < b) // expected-error {{Incompatible use of operator '<' on values of types 'Int' and 'Bool'}}
-    (a > c) // expected-error {{Incompatible use of operator '>' on values of types 'Int' and 'Address'}}
-    (a == d) // expected-error {{Incompatible use of operator '==' on values of unmatched types 'Int' and 'D'}}
-    (a == b) // expected-error {{Incompatible use of operator '==' on values of unmatched types 'Int' and 'Bool'}}
-    (d != d) // expected-error {{Incompatible use of operator '!=' on values of types 'D' and 'D'}}
+    a < 1
+    a < b // expected-error {{Incompatible use of operator '<' on values of types 'Int' and 'Bool'}}
+    a > c // expected-error {{Incompatible use of operator '>' on values of types 'Int' and 'Address'}}
+    a == d // expected-error {{Incompatible use of operator '==' on values of unmatched types 'Int' and 'D'}}
+    a == b // expected-error {{Incompatible use of operator '==' on values of unmatched types 'Int' and 'Bool'}}
+    d != d // expected-error {{Incompatible use of operator '!=' on values of types 'D' and 'D'}}
   }
 }
 


### PR DESCRIPTION
Fixes #48

# Implementation Overview

Adds two new TypeErrors for mismatched and invalid types for operators. These errors are invoked in a similar way to how the invalidAssignment error was generated previously. Refactored the processing of BinaryExpressions in TypeChecker.swift

# Notes

Should addresses and strings, or bools be comparable? This PR makes it so that they are not, and none of our tests use the comparison but I can see it would be useful in some situations.

I need to understand non-basic types a bit more to see if we can enable `==` and `!=` comparisons on them.

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Include tests
- [x] Add `review wanted` label, remove "WIP" in PR title
