### PR TITLE
Use PATH lookup to locate solc binary. 

### DIFF
--- a/Sources/flintc/SolcCompiler.swift
+++ b/Sources/flintc/SolcCompiler.swift
@@ -19,15 +19,11 @@ struct SolcCompiler {
 
     let process = Process()
 
-    #if os(Linux)
-      process.launchPath = "/usr/bin/solc"
-    #else
-      process.launchPath = "/usr/local/bin/solc"
-    #endif
+    process.launchPath = "/usr/bin/env"
 
     verifySolc(launchPath: process.launchPath!)
     process.standardError = Pipe()
-    process.arguments = [temporaryFile.path, "--bin"] + (emitBytecode ? ["--opcodes"] : []) + ["-o", outputDirectory.path]
+    process.arguments = ["solc", temporaryFile.path, "--bin"] + (emitBytecode ? ["--opcodes"] : []) + ["-o", outputDirectory.path]
 
     process.launch()
     process.waitUntilExit()


### PR DESCRIPTION
Fixes #297

# Implementation Overview

Use env instead of hardcoded path.

# Notes

N/A

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Include tests
- [x] Add `review wanted` label, remove "WIP" in PR title
