### PR TITLE
 Fix misleading statePropertyUsedWithinPropertyInitializer error 

### DIFF
--- a/Sources/AST/Environment.swift
+++ b/Sources/AST/Environment.swift
@@ -134,7 +134,7 @@ public struct Environment {
     return types[enclosingType]!.properties.keys.contains(property)
   }
 
-  /// Whether is property is declared as a constnat.
+  /// Whether property is declared as a constant.
   public func isPropertyConstant(_ property: String, enclosingType: RawTypeIdentifier) -> Bool {
     return types[enclosingType]!.properties[property]!.isConstant
   }
@@ -291,16 +291,16 @@ public struct Environment {
   public func type(ofRangeExpression rangeExpression: RangeExpression, enclosingType: RawTypeIdentifier, scopeContext: ScopeContext) -> Type.RawType {
     let elementType = type(of: rangeExpression.initial, enclosingType: enclosingType, scopeContext: scopeContext)
     let boundType   = type(of: rangeExpression.bound, enclosingType: enclosingType, scopeContext: scopeContext)
-    
+
     if elementType != boundType {
       // The bounds have different types.
       return .errorType
     }
-    
+
     return .rangeType(elementType)
   }
 
-  
+
   // The type of a dictionary literal.
   public func type(ofDictionaryLiteral dictionaryLiteral: DictionaryLiteral, enclosingType: RawTypeIdentifier, scopeContext: ScopeContext) -> Type.RawType {
     var keyType: Type.RawType?

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
@@ -282,7 +282,6 @@ public struct SemanticAnalyzer: ASTPass {
       }
 
       if let enclosingType = identifier.enclosingType {
-        // The identifier has an explicit enclosing type, such as `a` in the expression `a.foo`.
 
         if !passContext.environment!.isPropertyDefined(identifier.name, enclosingType: enclosingType) {
           // The property is not defined in the enclosing type.

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
@@ -233,6 +233,7 @@ public struct SemanticAnalyzer: ASTPass {
   }
 
   public func process(identifier: Identifier, passContext: ASTPassContext) -> ASTPassResult<Identifier> {
+    let environment = passContext.environment!
     var identifier = identifier
     var passContext = passContext
     var diagnostics = [Diagnostic]()
@@ -252,8 +253,12 @@ public struct SemanticAnalyzer: ASTPass {
     let inInitializerDeclaration = passContext.initializerDeclarationContext != nil
     let inFunctionOrInitializer = inFunctionDeclaration || inInitializerDeclaration
 
-    if passContext.isPropertyDefaultAssignment, !passContext.environment!.isStructDeclared(identifier.name) {
-      diagnostics.append(.statePropertyUsedWithinPropertyInitializer(identifier))
+    if passContext.isPropertyDefaultAssignment, !environment.isStructDeclared(identifier.name) {
+      if environment.isPropertyDefined(identifier.name, enclosingType: passContext.enclosingTypeIdentifier!.name) {
+        diagnostics.append(.statePropertyUsedWithinPropertyInitializer(identifier))
+      } else {
+        diagnostics.append(.useOfUndeclaredIdentifier(identifier))
+      }
     }
 
     if passContext.isFunctionCall {

--- a/Tests/SemanticTests/inits.flint
+++ b/Tests/SemanticTests/inits.flint
@@ -8,6 +8,7 @@ contract Test {
   var e: Bool
   var f: Int
   let g: Bool
+  let h: Int = completelyinvalid // expected-error {{Use of undeclared identifier 'completelyinvalid'}}
   var x: B
   var y: B = B(f, g) // expected-error {{Cannot use state property 'f' within the initialization of another property}}
                      // expected-error@-1 {{Cannot use state property 'g' within the initialization of another property}}
@@ -19,7 +20,7 @@ Test :: caller <- (any) {
     self.f = f
   } // expected-error {{Return from initializer without initializing all properties}}
     // expected-note@8 {{'e' is uninitialized}}
-    // expected-note@11 {{'x' is uninitialized}}
+    // expected-note@12 {{'x' is uninitialized}}
 
   public init() { // expected-error {{A public initializer has already been defined}}
     self.a = caller
@@ -38,7 +39,7 @@ Test :: caller <- (any) {
   }
 
   mutating func foo() {
-    x = B(1, true) 
+    x = B(1, true)
     x = C(1) // expected-error {{Incompatible assignment between values of type 'B' and 'C'}}
   }
 }


### PR DESCRIPTION
Fixes #300 

# Implementation Overview

Undefined identifiers now have separate errors to reusing state properties in initializers.

# Notes

N/A

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Include tests
- [x] Add `review wanted` label, remove "WIP" in PR title
