### PR TITLE
Add error when calling struct initializer without receiver

### DIFF
--- a/Sources/AST/ASTPassContext.swift
+++ b/Sources/AST/ASTPassContext.swift
@@ -112,6 +112,12 @@ extension ASTPassContext {
     return functionDeclarationContext != nil || initializerDeclarationContext != nil
   }
 
+  // Whether we are visiting a node inside the rhs of an assignment.
+  public var inAssignment: Bool {
+    get { return self[IsAssignment.self] ?? false }
+    set { self[IsAssignment.self] = newValue }
+  }
+
   /// Whether we are visiting a property's default assignment.
   public var isPropertyDefaultAssignment: Bool {
     get { return self[IsPropertyDefaultAssignment.self] ?? false }
@@ -163,6 +169,10 @@ private struct ScopeContextContextEntry: PassContextEntry {
 }
 
 private struct IsFunctionCallContextEntry: PassContextEntry {
+  typealias Value = Bool
+}
+
+private struct IsAssignment: PassContextEntry {
   typealias Value = Bool
 }
 

--- a/Sources/AST/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor.swift
@@ -37,7 +37,7 @@ public struct ASTVisitor<Pass: ASTPass> {
 
   func visit(_ topLevelDeclaration: TopLevelDeclaration, passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration> {
     var processResult = pass.process(topLevelDeclaration: topLevelDeclaration, passContext: passContext)
-    
+
     switch processResult.element {
     case .contractBehaviorDeclaration(let contractBehaviorDeclaration):
 
@@ -169,7 +169,7 @@ public struct ASTVisitor<Pass: ASTPass> {
 
     processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
     processResult.element.type = processResult.combining(visit(processResult.element.type, passContext: processResult.passContext))
-    
+
     if let assignedExpression = processResult.element.assignedExpression {
       let previousScopeContext = processResult.passContext.scopeContext
       // Create an empty scope context.
@@ -349,11 +349,11 @@ public struct ASTVisitor<Pass: ASTPass> {
     let postProcessResult = pass.postProcess(statement: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }
-  
+
   func visit(_ inoutExpression: InoutExpression, passContext: ASTPassContext) -> ASTPassResult<InoutExpression> {
     var processResult = pass.process(inoutExpression: inoutExpression, passContext: passContext)
     processResult.element.expression = processResult.combining(visit(processResult.element.expression, passContext: processResult.passContext))
-    
+
     let postProcessResult = pass.postProcess(inoutExpression: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }
@@ -374,7 +374,11 @@ public struct ASTVisitor<Pass: ASTPass> {
       processResult.passContext.asLValue = false
     }
 
+    if case .punctuation(let punctuation) = binaryExpression.op.kind, punctuation.isAssignment {
+      processResult.passContext.inAssignment = true
+    }
     processResult.element.rhs = processResult.combining(visit(processResult.element.rhs, passContext: processResult.passContext))
+    processResult.passContext.inAssignment = false // Allowed as nested assignments do not exist.
 
     let postProcessResult = pass.postProcess(binaryExpression: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
@@ -388,7 +392,7 @@ public struct ASTVisitor<Pass: ASTPass> {
     processResult.passContext.isFunctionCall = false
 
     processResult.element.arguments = processResult.element.arguments.map { argument in
-      
+
       let x = visit(argument, passContext: processResult.passContext)
       return processResult.combining(x)
     }
@@ -414,11 +418,11 @@ public struct ASTVisitor<Pass: ASTPass> {
     var element = processResult.element
     element.initial = processResult.combining(visit(element.initial, passContext: processResult.passContext))
     element.bound = processResult.combining(visit(element.bound, passContext: processResult.passContext))
-    
+
     let postProcessResult = pass.postProcess(rangeExpression: element, passContext: processResult.passContext)
     return ASTPassResult(element: element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }
-  
+
   func visit(_ dictionaryLiteral: DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<DictionaryLiteral> {
     var processResult = pass.process(dictionaryLiteral: dictionaryLiteral, passContext: passContext)
 
@@ -471,31 +475,31 @@ public struct ASTVisitor<Pass: ASTPass> {
     processResult.element.body = processResult.element.body.map { statement in
       return processResult.combining(visit(statement, passContext: processResult.passContext))
     }
-    
+
     if processResult.element.ifBodyScopeContext == nil {
       processResult.element.ifBodyScopeContext = processResult.passContext.scopeContext
     }
-    
+
     processResult.passContext.scopeContext = scopeContext
 
     processResult.element.elseBody = processResult.element.elseBody.map { statement in
       return processResult.combining(visit(statement, passContext: processResult.passContext))
     }
-    
+
     if processResult.element.elseBodyScopeContext == nil {
       processResult.element.elseBodyScopeContext = processResult.passContext.scopeContext
     }
-    
+
     processResult.passContext.scopeContext = scopeContext
 
     let postProcessResult = pass.postProcess(ifStatement: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }
-  
+
   func visit(_ forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement> {
     var passContext = passContext
     var processResult = pass.process(forStatement: forStatement, passContext: passContext)
-    
+
     processResult.element.variable = processResult.combining(visit(processResult.element.variable, passContext: processResult.passContext))
     processResult.element.iterable = processResult.combining(visit(processResult.element.iterable, passContext: processResult.passContext))
 
@@ -503,13 +507,13 @@ public struct ASTVisitor<Pass: ASTPass> {
     processResult.element.body = processResult.element.body.map { statement in
       return processResult.combining(visit(statement, passContext: processResult.passContext))
     }
- 
+
     if processResult.element.forBodyScopeContext == nil {
       processResult.element.forBodyScopeContext = processResult.passContext.scopeContext
     }
-    
+
     processResult.passContext.scopeContext = scopeContext
-    
+
     let postProcessResult = pass.postProcess(forStatement: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }

--- a/Sources/AST/Environment.swift
+++ b/Sources/AST/Environment.swift
@@ -291,16 +291,16 @@ public struct Environment {
   public func type(ofRangeExpression rangeExpression: RangeExpression, enclosingType: RawTypeIdentifier, scopeContext: ScopeContext) -> Type.RawType {
     let elementType = type(of: rangeExpression.initial, enclosingType: enclosingType, scopeContext: scopeContext)
     let boundType   = type(of: rangeExpression.bound, enclosingType: enclosingType, scopeContext: scopeContext)
-    
+
     if elementType != boundType {
       // The bounds have different types.
       return .errorType
     }
-    
+
     return .rangeType(elementType)
   }
 
-  
+
   // The type of a dictionary literal.
   public func type(ofDictionaryLiteral dictionaryLiteral: DictionaryLiteral, enclosingType: RawTypeIdentifier, scopeContext: ScopeContext) -> Type.RawType {
     var keyType: Type.RawType?
@@ -421,6 +421,7 @@ public struct Environment {
       type(of: $0, enclosingType: enclosingType, scopeContext: scopeContext)
     }
 
+    // Check if it can be a regular function.
     if let functions = types[enclosingType]?.functions[functionCall.identifier.name] {
       for candidate in functions {
         guard candidate.parameterTypes == argumentTypes,
@@ -433,6 +434,7 @@ public struct Environment {
       }
     }
 
+    // Check if it can be an initializer.
     if let initializers = types[functionCall.identifier.name]?.initializers {
       for candidate in initializers {
         guard candidate.parameterTypes == argumentTypes,
@@ -450,8 +452,7 @@ public struct Environment {
       }
     }
 
-    // Check if it's a global function.
-
+    // Check if it can be a global function.
     if let functions = types[Environment.globalFunctionStructName]?.functions[functionCall.identifier.name] {
       for candidate in functions {
 

--- a/Sources/IRGen/IULIAPreprocessor.swift
+++ b/Sources/IRGen/IULIAPreprocessor.swift
@@ -249,10 +249,11 @@ public struct IULIAPreprocessor: ASTPass {
     }
 
     // Mangle initializer call.
-    if environment.isStructDeclared(functionCall.identifier.name) {
+    if environment.isInitializerCall(functionCall) {
       // Remove the receiver as the first argument to find the original initializer declaration.
       var initializerWithoutReceiver = functionCall
-      if passContext.functionDeclarationContext != nil || passContext.initializerDeclarationContext != nil {
+      if passContext.functionDeclarationContext != nil || passContext.initializerDeclarationContext != nil,
+        !initializerWithoutReceiver.arguments.isEmpty {
         initializerWithoutReceiver.arguments.remove(at: 0)
       }
 
@@ -283,7 +284,6 @@ public struct IULIAPreprocessor: ASTPass {
     guard environment.matchEventCall(functionCall, enclosingType: enclosingType) == nil else {
       return ASTPassResult(element: functionCall, diagnostics: [], passContext: passContext)
     }
-
     // For each non-implicit dynamic type, add an isMem parameter.
     var offset = 0
     for (index, argument) in functionCall.arguments.enumerated() {
@@ -378,7 +378,7 @@ public struct IULIAPreprocessor: ASTPass {
   public func process(rangeExpression: AST.RangeExpression, passContext: ASTPassContext) -> ASTPassResult<AST.RangeExpression> {
     return ASTPassResult(element: rangeExpression, diagnostics: [], passContext: passContext)
   }
-  
+
   public func process(dictionaryLiteral: AST.DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<AST.DictionaryLiteral> {
     return ASTPassResult(element: dictionaryLiteral, diagnostics: [], passContext: passContext)
   }
@@ -398,7 +398,7 @@ public struct IULIAPreprocessor: ASTPass {
   public func process(ifStatement: IfStatement, passContext: ASTPassContext) -> ASTPassResult<IfStatement> {
     return ASTPassResult(element: ifStatement, diagnostics: [], passContext: passContext)
   }
-  
+
   public func process(forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement> {
     return ASTPassResult(element: forStatement, diagnostics: [], passContext: passContext)
   }
@@ -487,7 +487,7 @@ public struct IULIAPreprocessor: ASTPass {
   public func postProcess(functionCall: FunctionCall, passContext: ASTPassContext) -> ASTPassResult<FunctionCall> {
     return ASTPassResult(element: functionCall, diagnostics: [], passContext: passContext)
   }
-  
+
   public func postProcess(rangeExpression: AST.RangeExpression, passContext: ASTPassContext) -> ASTPassResult<AST.RangeExpression> {
     return ASTPassResult(element: rangeExpression, diagnostics: [], passContext: passContext)
   }

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -28,18 +28,22 @@ extension Diagnostic {
     let candidateNotes = candidates.map { candidate -> Diagnostic in
       let callerCapabilities = renderCapabilityGroup(candidate.callerCapabilities)
       let messageTail: String
-      
+
       if candidate.callerCapabilities.count > 1 {
         messageTail = "one of the caller capabilities in '(\(callerCapabilities))'"
       } else {
         messageTail = "the caller capability '\(callerCapabilities)'"
       }
-      
+
       return Diagnostic(severity: .note, sourceLocation: candidate.declaration.sourceLocation, message: "Perhaps you meant this function, which requires \(messageTail)")
     }
-    
+
     let plural = contextCallerCapabilities.count > 1
     return Diagnostic(severity: .error, sourceLocation: functionCall.sourceLocation, message: "Function '\(functionCall.identifier.name)' is not in scope or cannot be called using the caller \(plural ? "capabilities" : "capability") '\(renderCapabilityGroup(contextCallerCapabilities))'", notes: candidateNotes)
+  }
+
+  static func noReceiverForStructInitializer(_ functionCall: FunctionCall) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: functionCall.sourceLocation, message: "Cannot call struct initializer '\(functionCall.identifier.name)' without receiver assignment")
   }
 
   static func contractBehaviorDeclarationNoMatchingContract(_ contractBehaviorDeclaration: ContractBehaviorDeclaration) -> Diagnostic {
@@ -57,7 +61,7 @@ extension Diagnostic {
   static func payableFunctionDoesNotHavePayableValueParameter(_ functionDeclaration: FunctionDeclaration) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation, message: "Function '\(functionDeclaration.identifier.name)' is declared @payable but doesn't have an implicit parameter of a currency type")
   }
-  
+
   static func payableFunctionHasNonPayableValueParameter(_ functionDeclaration: FunctionDeclaration) -> Diagnostic {
       return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation, message: "Payable function '\(functionDeclaration.identifier.name)' has an implicit parameter of non-currency type")
   }
@@ -103,7 +107,7 @@ extension Diagnostic {
   static func statePropertyUsedWithinPropertyInitializer(_ identifier: Identifier) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation, message: "Cannot use state property '\(identifier.name)' within the initialization of another property")
   }
-  
+
   static func invalidRangeDeclaration(_ literalExpression: Expression) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: literalExpression.sourceLocation, message: "Cannot create ranges of non-numeric literals")
   }
@@ -112,7 +116,7 @@ extension Diagnostic {
     let note = Diagnostic(severity: .note, sourceLocation: enclosingType.sourceLocation, message: "State property '\(enclosingType.variableDeclaration.identifier.name)' of type '\(enclosingType.rawType.name)' refers to enclosing type of '\(structIdentifier.name)'")
     return Diagnostic(severity: .error, sourceLocation: structIdentifier.sourceLocation, message: "Declaration of recursive struct '\(structIdentifier.name)'", notes: [note])
   }
-    
+
   static func returnFromInitializerWithoutInitializingAllProperties(_ initializerDeclaration: InitializerDeclaration, unassignedProperties: [VariableDeclaration]) -> Diagnostic {
     let notes = unassignedProperties.map { property in
       return Diagnostic(severity: .note, sourceLocation: property.sourceLocation, message: "'\(property.identifier.name)' is uninitialized")
@@ -129,7 +133,7 @@ extension Diagnostic {
     let note = Diagnostic(severity: .note, sourceLocation: originalInitializerLocation, message: "A public initializer is already declared here")
     return Diagnostic(severity: .error, sourceLocation: invalidAdditionalInitializer.sourceLocation, message: "A public initializer has already been defined", notes: [note])
   }
-  
+
   static func contractInitializerNotDeclaredInAnyCallerCapabilityBlock(_ initializerDeclaration: InitializerDeclaration) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: initializerDeclaration.sourceLocation, message: "Public contract initializer should be callable using caller capability 'any'")
   }
@@ -145,7 +149,7 @@ extension Diagnostic {
   static func codeAfterReturn(_ statement: Statement) -> Diagnostic {
     return Diagnostic(severity: .warning, sourceLocation: statement.sourceLocation, message: "Code after return will never be executed")
   }
-  
+
   static func emptyRange(_ rangeExpression: AST.RangeExpression) -> Diagnostic {
     return Diagnostic(severity: .warning, sourceLocation: rangeExpression.sourceLocation, message: "Range is empty therefore content will be skipped")
   }

--- a/Tests/SemanticTests/inits.flint
+++ b/Tests/SemanticTests/inits.flint
@@ -38,8 +38,9 @@ Test :: caller <- (any) {
   }
 
   mutating func foo() {
-    x = B(1, true) 
+    x = B(1, true)
     x = C(1) // expected-error {{Incompatible assignment between values of type 'B' and 'C'}}
+    D() // expected-error {{Cannot call struct initializer 'D' without receiver assignment}}
   }
 }
 


### PR DESCRIPTION
Fixes #305 

# Implementation Overview

Add passContext property inAssignment to detect (lack of) assignment of initializers.

# Notes

N/A

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Include tests
- [x] Add `review wanted` label, remove "WIP" in PR title
