### PR TITLE
WIP: Rewrite types to isolate from Environment

### DIFF
--- a/Sources/AST/Component/TypeIdentifier.swift
+++ b/Sources/AST/Component/TypeIdentifier.swift
@@ -1,0 +1,31 @@
+//
+//  TypeIdentifier.swift
+//  AST
+//
+//  Created by Hails, Daniel R on 31/08/2018.
+//
+
+import Source
+import Lexer
+
+/// A type annotation for a variable.
+public struct TypeIdentifier: ASTNode {
+  public let name: Identifier
+  public let genericArguments: [TypeIdentifier]
+
+  public init(name: Identifier, genericArguments: [TypeIdentifier] = []) {
+    self.name = name
+    self.genericArguments = genericArguments
+  }
+
+  // MARK: - ASTNode
+  public var description: String {
+    return "\(name)<\(genericArguments.map({ $0.description }).joined(separator: ", "))>"
+  }
+  public var sourceLocation: SourceLocation {
+    if genericArguments.isEmpty {
+      return name.sourceLocation
+    }
+    return .spanning(name, to: genericArguments.last!)
+  }
+}

--- a/Sources/AST/Environment/Type.swift
+++ b/Sources/AST/Environment/Type.swift
@@ -1,0 +1,174 @@
+//
+//  Type.swift
+//  AST
+//
+//  Created by Hails, Daniel J R on 21/08/2018.
+//
+import Lexer
+import Source
+/// The raw representation of an RawType.
+public typealias RawTypeIdentifier = String
+
+// A Flint raw type, without a source location.
+public indirect enum RawType: Equatable {
+  case basicType(BasicType)
+  case contractType(RawTypeIdentifier)
+  case structType(RawTypeIdentifier)
+  case enumType(RawTypeIdentifier)
+  case rangeType(RawType)
+  case arrayType(RawType)
+  case fixedSizeArrayType(RawType, size: Int)
+  case dictionaryType(key: RawType, value: RawType)
+  case inoutType(RawType)
+  case any
+  case errorType
+
+  public enum BasicType: RawTypeIdentifier {
+    case address = "Address"
+    case int = "Int"
+    case string = "String"
+    case void = "Void"
+    case bool = "Bool"
+    case event = "Event"
+
+    var isCallerCapabilityType: Bool {
+      switch self {
+      case .address: return true
+      default: return false
+      }
+    }
+  }
+
+  public var name: String {
+    switch self {
+    case .fixedSizeArrayType(let rawType, size: let size): return "\(rawType.name)[\(size)]"
+    case .arrayType(let rawType): return "[\(rawType.name)]"
+    case .rangeType(let rawType): return "(\(rawType.name))"
+    case .basicType(let builtInType): return "\(builtInType.rawValue)"
+    case .dictionaryType(let keyType, let valueType): return "[\(keyType.name): \(valueType.name)]"
+    case .inoutType(let rawType): return "$inout\(rawType.name)"
+    case .any: return "Any"
+    case .errorType: return "Flint$ErrorType"
+    case .contractType(let identifier): return "Contract<\(identifier)>"
+    case .structType(let identifier): return "Struct<\(identifier)>"
+    case .enumType(let identifier): return "Enum<\(identifier)>"
+    }
+  }
+
+  public var isEventType: Bool {
+    return self == .basicType(.event)
+  }
+
+  /// Whether the type is a dynamic type.
+  public var isDynamicType: Bool {
+    if case .basicType(_) = self {
+      return false
+    }
+
+    return true
+  }
+
+  /// Whether the type is compatible with the given type, i.e., if two expressions of those types can be used
+  /// interchangeably.
+  public func isCompatible(with otherType: RawType) -> Bool {
+    if self == .any || otherType == .any { return true }
+    guard self != otherType else { return true }
+
+    switch (self, otherType) {
+    case (.arrayType(let e1), .arrayType(let e2)):
+      return e1.isCompatible(with: e2)
+    case (.fixedSizeArrayType(let e1, _), .fixedSizeArrayType(let e2, _)):
+      return e1.isCompatible(with: e2)
+    case (.fixedSizeArrayType(let e1, _), .arrayType(let e2)):
+      return e1.isCompatible(with: e2)
+    case (.dictionaryType(let key1, let value1), .dictionaryType(let key2, let value2)):
+      return key1.isCompatible(with: key2) && value1.isCompatible(with: value2)
+    default: return false
+    }
+  }
+}
+
+
+/// A Flint type.
+public struct Type: ASTNode {
+  public var rawType: RawType
+  public var genericArguments = [Type]()
+
+  public var name: String {
+    return rawType.name
+  }
+
+  var isCurrencyType: Bool {
+    switch rawType {
+    case .structType("Wei"): return true
+    default: return false
+    }
+  }
+
+  // Initializers for each kind of raw type.
+
+  public init(builtIn: Identifier, genericArguments: [Type] = []) throws {
+    let name = builtIn.name
+    guard let builtInType = RawType.BasicType(rawValue: name) else {
+      fatalError("Called init(builtIn: .. ) with identifier that was not built in")
+    }
+    self.rawType = .basicType(builtInType)
+    self.genericArguments = genericArguments
+    self.sourceLocation = builtIn.sourceLocation
+  }
+
+  public init(contract: Identifier, genericArguments: [Type] = []) {
+    self.rawType = .contractType(contract.name)
+    self.genericArguments = genericArguments
+    self.sourceLocation = contract.sourceLocation
+  }
+
+  public init(structure: Identifier, genericArguments: [Type] = []) {
+    self.rawType = .structType(structure.name)
+    self.genericArguments = genericArguments
+    self.sourceLocation = structure.sourceLocation
+  }
+
+  public init(enumeration: Identifier) {
+    self.rawType = .enumType(enumeration.name)
+    self.genericArguments = []
+    self.sourceLocation = enumeration.sourceLocation
+  }
+
+  public init(ampersandToken: Token, inoutType: Type) {
+    rawType = .inoutType(inoutType.rawType)
+    sourceLocation = ampersandToken.sourceLocation
+  }
+
+  public init(inoutToken: Token, inoutType: Type) {
+    rawType = .inoutType(inoutType.rawType)
+    sourceLocation = inoutToken.sourceLocation
+  }
+
+  public init(openSquareBracketToken: Token, arrayWithElementType type: Type, closeSquareBracketToken: Token) {
+    rawType = .arrayType(type.rawType)
+    sourceLocation = .spanning(openSquareBracketToken, to: closeSquareBracketToken)
+  }
+
+  public init(fixedSizeArrayWithElementType type: Type, size: Int, closeSquareBracketToken: Token) {
+    rawType = .fixedSizeArrayType(type.rawType, size: size)
+    sourceLocation = .spanning(type, to: closeSquareBracketToken)
+  }
+
+  public init(openSquareBracketToken: Token, dictionaryWithKeyType keyType: Type, valueType: Type, closeSquareBracketToken: Token) {
+    rawType = .dictionaryType(key: keyType.rawType, value: valueType.rawType)
+    sourceLocation = .spanning(openSquareBracketToken, to: closeSquareBracketToken)
+  }
+
+  public init(inferredType: RawType, identifier: Identifier) {
+    rawType = inferredType
+    sourceLocation = identifier.sourceLocation
+  }
+
+  // MARK: - ASTNode
+  public var sourceLocation: SourceLocation
+
+  public var description: String {
+    return name
+  }
+}

--- a/Sources/Parser/Parser+Type.swift
+++ b/Sources/Parser/Parser+Type.swift
@@ -1,0 +1,97 @@
+//
+//  Parser+Type.swift
+//  AST
+//
+//  Created by Hails, Daniel R on 31/08/2018.
+//
+
+import AST
+import Lexer
+import Source
+
+extension Parser {
+  func parseTypeAnnotation() throws -> TypeAnnotation {
+    let colonToken = try consume(.punctuation(.colon))
+    let type = try parseType()
+    return TypeAnnotation(colonToken: colonToken, type: type)
+  }
+
+  func parseType() throws -> Type {
+    let atomicType = try parseAtomicType()
+    return try parseContainerType(atomicType, attributes: attrs)
+  }
+
+  func parseAtomicType() throws -> Type {
+    if let openSquareBracketToken = attempt(try consume(.punctuation(.openSquareBracket))) {
+      return try parseCollectionType()
+    }
+    if let anyToken = try? consume(.any) {
+      return AnyType(anyToken)
+    }
+    if let selfToken = try? consume(.self) {
+      return SelfType(selfToken)
+    }
+
+    return 
+  }
+}
+
+func parseType() throws -> TypeIdentifier {
+  if let openSquareBracketToken = attempt(try consume(.punctuation(.openSquareBracket))) {
+    // The type is an array type or a dictionary type.
+    let keyType = try parseType()
+    if attempt(try consume(.punctuation(.colon))) != nil {
+      // The type is a dictionary type.
+      let valueType = try parseType()
+      let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket))
+      return Type(openSquareBracketToken: openSquareBracketToken, dictionaryWithKeyType: keyType, valueType: valueType, closeSquareBracketToken: closeSquareBracketToken)
+    }
+
+    let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket))
+    return Type(openSquareBracketToken: openSquareBracketToken, arrayWithElementType: keyType, closeSquareBracketToken: closeSquareBracketToken)
+  }
+
+  if let inoutToken = attempt(try consume(.inout)) {
+    // The type is declared inout (valid only for function parameters).
+    let type = try parseType()
+    return Type(ampersandToken: inoutToken, inoutType: type)
+  }
+
+  let identifier = try parseIdentifier()
+  let type = TypeIdentifier(identifier: identifier)
+
+  if attempt(try consume(.punctuation(.openSquareBracket))) != nil {
+    // The type is a fixed-size array.
+
+    // Get the array's size.
+    let literal = try parseLiteral()
+
+    // Ensure the literal is an integer.
+    guard case .literal(.decimal(.integer(let size))) = literal.kind else {
+      throw ParserError.expectedToken(.literal(.decimal(.integer(0))), sourceLocation: literal.sourceLocation)
+    }
+
+    let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket))
+    return Type(fixedSizeArrayWithElementType: type, size: size, closeSquareBracketToken: closeSquareBracketToken)
+  }
+
+  if attempt(try consume(.punctuation(.openAngledBracket))) != nil {
+    // The type has generic arguments.
+    var genericArguments = [Type]()
+    while true {
+      let genericArgument = try parseType()
+      genericArguments.append(genericArgument)
+
+      // If the next token is not a comma, stop parsing generic arguments.
+      if attempt(try consume(.punctuation(.comma))) == nil {
+        break
+      }
+    }
+    try consume(.punctuation(.closeAngledBracket))
+    return TypeIdentifier(identifier: identifier, genericArguments: genericArguments)
+  }
+
+  return type
+}
+
+

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -349,70 +349,6 @@ extension Parser {
 
     return base
   }
-
-  func parseType() throws -> Type {
-    if let openSquareBracketToken = attempt(try consume(.punctuation(.openSquareBracket))) {
-      // The type is an array type or a dictionary type.
-      let keyType = try parseType()
-      if attempt(try consume(.punctuation(.colon))) != nil {
-        // The type is a dictionary type.
-        let valueType = try parseType()
-        let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket))
-        return Type(openSquareBracketToken: openSquareBracketToken, dictionaryWithKeyType: keyType, valueType: valueType, closeSquareBracketToken: closeSquareBracketToken)
-      }
-
-      let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket))
-      return Type(openSquareBracketToken: openSquareBracketToken, arrayWithElementType: keyType, closeSquareBracketToken: closeSquareBracketToken)
-    }
-
-    if let inoutToken = attempt(try consume(.inout)) {
-      // The type is declared inout (valid only for function parameters).
-      let type = try parseType()
-      return Type(ampersandToken: inoutToken, inoutType: type)
-    }
-
-    let identifier = try parseIdentifier()
-    let type = Type(identifier: identifier)
-
-    if attempt(try consume(.punctuation(.openSquareBracket))) != nil {
-      // The type is a fixed-size array.
-
-      // Get the array's size.
-      let literal = try parseLiteral()
-
-      // Ensure the literal is an integer.
-      guard case .literal(.decimal(.integer(let size))) = literal.kind else {
-        throw ParserError.expectedToken(.literal(.decimal(.integer(0))), sourceLocation: literal.sourceLocation)
-      }
-
-      let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket))
-      return Type(fixedSizeArrayWithElementType: type, size: size, closeSquareBracketToken: closeSquareBracketToken)
-    }
-
-    if attempt(try consume(.punctuation(.openAngledBracket))) != nil {
-      // The type has generic arguments.
-      var genericArguments = [Type]()
-      while true {
-        let genericArgument = try parseType()
-        genericArguments.append(genericArgument)
-
-        // If the next token is not a comma, stop parsing generic arguments.
-        if attempt(try consume(.punctuation(.comma))) == nil {
-          break
-        }
-      }
-      try consume(.punctuation(.closeAngledBracket))
-      return Type(identifier: identifier, genericArguments: genericArguments)
-    }
-
-    return type
-  }
-
-  func parseTypeAnnotation() throws -> TypeAnnotation {
-    let colonToken = try consume(.punctuation(.colon))
-    let type = try parseType()
-    return TypeAnnotation(colonToken: colonToken, type: type)
-  }
 }
 
 extension Parser {
@@ -630,8 +566,7 @@ extension Parser {
 
   func parseResult() throws -> Type {
     try consume(.punctuation(.arrow))
-    let identifier = try parseIdentifier()
-    return Type(identifier: identifier)
+    return try parseType()
   }
 
   func parseCodeBlock() throws -> ([Statement], closeBraceToken: Token) {
@@ -924,7 +859,7 @@ extension Parser {
     if attempt(try consume(.punctuation(.equal))) != nil {
       hiddenValue = try parseExpression(upTo: indexOfFirstAtCurrentDepth([.newline])!)
     }
-    return EnumCase(caseToken: caseToken, identifier: identifier, type: Type(identifier: enumIdentifier), hiddenValue: hiddenValue, hiddenType: hiddenType)
+    return EnumCase(caseToken: caseToken, identifier: identifier, type: enumIdentifier, hiddenValue: hiddenValue, hiddenType: hiddenType)
   }
 
 }


### PR DESCRIPTION
# Implementation Overview
Types in the AST are the same types that are in the environment. This leads to some cross-contamination between modules and jury rigging the types to work for both process. This PR will isolate the two and provide two separate and distinct system for environmental checks and AST creation.

# Notes

# Checklist

- [ ] Remove all TODOs, debug prints, whitespace changes
- [ ] Update docs/grammar.abnf if necessary
- [ ] Include tests
- [ ] Add `review wanted` label, remove "WIP" in PR title
