### PR TITLE
WIP: Revert if a non-payable function is called with value.

### DIFF
--- a/Sources/IRGen/Runtime/IRFunctionSelector.swift
+++ b/Sources/IRGen/Runtime/IRFunctionSelector.swift
@@ -61,6 +61,14 @@ struct IRFunctionSelector {
     let callerCapabilities = function.callerCapabilities
     let callerCapabilityChecks = IRCallerCapabilityChecks(callerCapabilities: callerCapabilities).rendered(enclosingType: enclosingType.name, environment: environment)
 
+    // Dynamically check the function is not being called with value, if it is not payable.
+    let valueChecks: String
+    if !function.functionDeclaration.isPayable {
+      valueChecks = IRRuntimeFunction.checkNoValue(IRRuntimeFunction.callvalue()) + "\n"
+    } else {
+      valueChecks = ""
+    }
+
     let arguments = function.parameterCanonicalTypes.enumerated().map { arg -> String in
       let (index, type) = arg
       switch type {
@@ -77,7 +85,7 @@ struct IRFunctionSelector {
       }
     }
 
-    return "\(typeStateChecks)\n\(callerCapabilityChecks)\n\(call)"
+    return "\(typeStateChecks)\n\(callerCapabilityChecks)\n\(valueChecks)\(call)"
   }
 }
 

--- a/Sources/IRGen/Runtime/IRRuntimeFunction.swift
+++ b/Sources/IRGen/Runtime/IRRuntimeFunction.swift
@@ -17,6 +17,7 @@ enum IRRuntimeFunction {
     case load
     case computeOffset
     case allocateMemory
+    case checkNoValue
     case isMatchingTypeState
     case isValidCallerCapability
     case isCallerCapabilityInArray
@@ -31,6 +32,7 @@ enum IRRuntimeFunction {
     case storageOffsetForKey
     case callvalue
     case send
+    case fatalError
     case add
     case sub
     case mul
@@ -40,6 +42,10 @@ enum IRRuntimeFunction {
     var mangled: String {
       return "\(Environment.runtimeFunctionPrefix)\(self)"
     }
+  }
+
+  static func fatalError() -> String {
+    return "\(Identifiers.fatalError.mangled)()"
   }
 
   static func selector() -> String {
@@ -80,6 +86,10 @@ enum IRRuntimeFunction {
 
   static func allocateMemory(size: Int) -> String {
     return "\(Identifiers.allocateMemory.mangled)(\(size))"
+  }
+
+  static func checkNoValue(_ value: String) -> String {
+    return "\(Identifiers.checkNoValue.mangled)(\(value))"
   }
 
   static func isMatchingTypeState(_ stateValue: String, _ stateVariable: String) -> String {
@@ -163,6 +173,7 @@ enum IRRuntimeFunction {
     IRRuntimeFunctionDeclaration.load,
     IRRuntimeFunctionDeclaration.computeOffset,
     IRRuntimeFunctionDeclaration.allocateMemory,
+    IRRuntimeFunctionDeclaration.checkNoValue,
     IRRuntimeFunctionDeclaration.isMatchingTypeState,
     IRRuntimeFunctionDeclaration.isValidCallerCapability,
     IRRuntimeFunctionDeclaration.isCallerCapabilityInArray,
@@ -250,6 +261,15 @@ struct IRRuntimeFunctionDeclaration {
   function flint$allocateMemory(size) -> ret {
     ret := mload(0x40)
     mstore(0x40, add(ret, size))
+  }
+  """
+
+  static let checkNoValue =
+  """
+  function flint$checkNoValue(_value) {
+    if iszero(iszero(_value)) {
+      flint$fatalError()
+    }
   }
   """
 

--- a/Tests/BehaviorTests/tests/assert/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/assert/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/Tests/BehaviorTests/tests/assert/test/test/test.js
+++ b/Tests/BehaviorTests/tests/assert/test/test/test.js
@@ -11,7 +11,7 @@ contract(config.contractName, function(accounts) {
     const instance = await Contract.deployed();
 
     try {
-      await instance.shouldCrash();
+      await instance.shouldCrash.call();
     } catch (e) {
       return
     }
@@ -22,8 +22,6 @@ contract(config.contractName, function(accounts) {
   it("should not crash on assertion success", async function() {
     const instance = await Contract.deployed();
 
-    await instance.shouldNotCrash();
+    await instance.shouldNotCrash.call();
   });
 });
-
-

--- a/Tests/BehaviorTests/tests/bank/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/bank/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/Tests/BehaviorTests/tests/caller/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/caller/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/Tests/BehaviorTests/tests/currency/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/currency/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/Tests/BehaviorTests/tests/dictionary/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/dictionary/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/Tests/BehaviorTests/tests/enums/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/enums/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/Tests/BehaviorTests/tests/factorial/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/factorial/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/Tests/BehaviorTests/tests/inits/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/inits/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/Tests/BehaviorTests/tests/loop/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/loop/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/Tests/BehaviorTests/tests/memory/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/memory/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/Tests/BehaviorTests/tests/operators/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/operators/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/Tests/BehaviorTests/tests/structs/test/test/.placeholder
+++ b/Tests/BehaviorTests/tests/structs/test/test/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.


### PR DESCRIPTION
Fixes #212

# Implementation Overview

Non-payable functions have a check inserted in the selector which ensures that no value is present.

# Notes

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Update docs/grammar.abnf if necessary
- [ ] Include tests
- [ ] Add `review wanted` label, remove "WIP" in PR title
