### PR TITLE
Allow type state specifications to follow directly after contract nam…

### DIFF
--- a/Sources/AST/Component/Attribute.swift
+++ b/Sources/AST/Component/Attribute.swift
@@ -11,12 +11,14 @@ import Lexer
 public struct Attribute: ASTNode {
 
   var kind: Kind
-  var token: Token
+  var atToken: Token
+  var identifierToken: Token
 
-  public init?(token: Token) {
-    guard case .attribute(let attribute) = token.kind, let kind = Kind(rawValue: attribute) else { return nil }
+  public init?(atToken: Token, identifierToken: Token) {
+    guard case .identifier(let attribute) = identifierToken.kind, let kind = Kind(rawValue: attribute) else { return nil }
     self.kind = kind
-    self.token = token
+    self.atToken = atToken
+    self.identifierToken = identifierToken
   }
 
   enum Kind: String {
@@ -25,9 +27,12 @@ public struct Attribute: ASTNode {
 
   // MARK: - ASTNode
   public var description: String {
-    return token.kind.description
+    guard case .identifier(let identifier) = identifierToken.kind else {
+      fatalError()
+    }
+    return "@\(identifier)"
   }
   public var sourceLocation: SourceLocation {
-    return token.sourceLocation
+    return .spanning(atToken, to: identifierToken)
   }
 }

--- a/Sources/Lexer/Lexer.swift
+++ b/Sources/Lexer/Lexer.swift
@@ -59,9 +59,6 @@ public struct Lexer {
       } else if let first = component.first, let last = component.last, first == "\"", first == last {
         // The token is a string literal.
         tokens.append(Token(kind: .literal(.string(String(component[(component.index(after: component.startIndex)..<component.index(before: component.endIndex))]))), sourceLocation: sourceLocation))
-      } else if component.first == "@" {
-        // The token is a function attribute.
-        tokens.append(Token(kind: .attribute(String(component.dropFirst())), sourceLocation: sourceLocation))
       } else {
         // The token is an identifier.
         tokens.append(Token(kind: .identifier(component), sourceLocation: sourceLocation))
@@ -177,7 +174,7 @@ public struct Lexer {
         acc += String(char)
       } else if inStringLiteral {
         acc += String(char)
-      } else if identifierChars.contains(char.unicodeScalars.first!) || char == "@" || char == "_" {
+      } else if identifierChars.contains(char.unicodeScalars.first!) || char == "_" {
         acc += String(char)
       } else {
         if !acc.isEmpty {

--- a/Sources/Lexer/Token.swift
+++ b/Sources/Lexer/Token.swift
@@ -24,9 +24,6 @@ public struct Token: Equatable, SourceEntity, CustomStringConvertible {
     // Punctuation
     case punctuation(Punctuation)
 
-    // Declaration attribute
-    case attribute(String)
-
     // Identifiers
     case identifier(String)
 
@@ -66,7 +63,6 @@ public struct Token: Equatable, SourceEntity, CustomStringConvertible {
       case .in: return "in"
       case .try: return "try"
       case .punctuation(let punctuation): return punctuation.rawValue
-      case .attribute(let attribute): return "@\(attribute)"
       case .identifier(let identifier): return "identifier \"\(identifier)\""
       case .literal(let literal): return literal.description
       }

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -213,8 +213,9 @@ extension Parser {
   }
 
   func parseAttribute() throws -> Attribute {
-    guard let token = currentToken, let attribute = Attribute(token: token) else {
-      throw ParserError.expectedToken(.attribute(""), sourceLocation: currentToken?.sourceLocation)
+    let at = try consume(.punctuation(.at))
+    guard let token = currentToken, let attribute = Attribute(atToken: at, identifierToken: token) else {
+      throw ParserError.expectedToken(.identifier(""), sourceLocation: currentToken?.sourceLocation)
     }
     currentIndex += 1
     consumeNewLines()
@@ -872,7 +873,7 @@ extension Parser {
     try consume(.punctuation(.openBrace))
     let members = try parseStructMembers(structIdentifier: identifier)
     try consume(.punctuation(.closeBrace))
-    
+
     return StructDeclaration(structToken: structToken, identifier: identifier, members: members)
   }
 

--- a/Tests/SemanticTests/invalid_identifiers.flint
+++ b/Tests/SemanticTests/invalid_identifiers.flint
@@ -5,6 +5,5 @@
 struct $ { // expected-error {{Use of invalid character '$' in '$'}}
   func foo$() { // expected-error {{Use of invalid character '$' in 'foo$'}}
     let a$ap: Int = 0 // expected-error {{Use of invalid character '$' in 'a$ap'}}
-    let as@p: Int = 0 // expected-error {{Use of invalid character '@' in 'as@p'}}
   }
 }

--- a/Tests/SemanticTests/type_states.flint
+++ b/Tests/SemanticTests/type_states.flint
@@ -2,7 +2,7 @@
 
 contract Normal {}
 
-Normal @(any) :: (any) { // expected-error {{Contract 'Normal' is not stateful but behavior declaration is}}
+Normal@(any) :: (any) { // expected-error {{Contract 'Normal' is not stateful but behavior declaration is}}
   public init() {}
 }
 

--- a/docs/grammar.abnf
+++ b/docs/grammar.abnf
@@ -45,7 +45,7 @@ structMember = variableDeclaration
                 / initializerDeclaration;
 
 ; BEHAVIOUR
-contractBehaviourDeclaration = identifier SP [stateGroup] SP "::" WSP [callerCapabilityBinding] callerCapabilityGroup WSP "{" *(WSP contractBehaviourMember CRLF) "}";
+contractBehaviourDeclaration = identifier WSP [stateGroup] SP "::" WSP [callerCapabilityBinding] callerCapabilityGroup WSP "{" *(WSP contractBehaviourMember CRLF) "}";
 
 contractBehaviourMember = functionDeclaration
                             / initializerDeclaration


### PR DESCRIPTION
…e without spaces.

Fixes #288 

# Implementation Overview

Split tokens on `@` in the lexer. Remove attribute token type and modify Attribute ast node to use combination of `@` token and identifier.

# Notes

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Update docs/grammar.abnf if necessary
- [x] Include tests
- [x] Add `review wanted` label, remove "WIP" in PR title
