### PR TITLE
Add quiet flag to supress warnings, and use for compiling behaviour t…

### DIFF
--- a/Sources/flintc/main.swift
+++ b/Sources/flintc/main.swift
@@ -11,8 +11,9 @@ func main() {
     Flag("emit-bytecode", flag: "b", description: "Emit the EVM bytecode representation of the code."),
     Flag("dump-ast", flag: "a", description: "Print the abstract syntax tree of the code."),
     Flag("verify", flag: "v", description: "Verify expected diagnostics were produced."),
+    Flag("quiet", flag: "q", description: "Supress warnings and only emit fatal errors."),
     VariadicArgument<String>("input files", description: "The input files to compile.")
-  ) { emitIR, irOutputPath, emitBytecode, dumpAST, shouldVerify, inputFilePaths in
+  ) { emitIR, irOutputPath, emitBytecode, dumpAST, shouldVerify, quiet, inputFilePaths in
     let inputFiles = inputFilePaths.map(URL.init(fileURLWithPath:))
 
     for inputFile in inputFiles {
@@ -23,13 +24,14 @@ func main() {
 
     let outputDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent("bin")
     try! FileManager.default.createDirectory(atPath: outputDirectory.path, withIntermediateDirectories: true, attributes: nil)
-    
+
     let compilationOutcome = Compiler(
       inputFiles: inputFiles,
       stdlibFiles: StandardLibrary.default.files,
       outputDirectory: outputDirectory,
       emitBytecode: emitBytecode,
-      shouldVerify: shouldVerify
+      shouldVerify: shouldVerify,
+      quiet: quiet
     ).compile()
 
     if emitIR {

--- a/Tests/BehaviorTests/compile_behavior_tests.sh
+++ b/Tests/BehaviorTests/compile_behavior_tests.sh
@@ -5,7 +5,7 @@ for t in tests/*; do
   mkdir $t/test/contracts
 
   echo "Compile $t"
-  ../../.build/release/flintc $t/*.flint --emit-ir --ir-output $t/test/contracts/
+  ../../.build/release/flintc $t/*.flint --emit-ir --ir-output $t/test/contracts/ --quiet
 
   #for f in $t/*.flint; do
     #[ -f "$f" ] || break
@@ -14,4 +14,3 @@ for t in tests/*; do
 
   echo "pragma solidity ^0.4.2; contract Migrations {}" > $t/test/contracts/Migrations.sol
 done
-


### PR DESCRIPTION
…ests.

Fixes #333 

# Implementation Overview

Filter warnings after compilation, if quiet flag is set.

# Notes

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Update docs/grammar.abnf if necessary
- [x] Include tests
- [x] Add `review wanted` label, remove "WIP" in PR title
