### PR TITLE
Parse conformations

### DIFF
--- a/Sources/AST/ASTDumper.swift
+++ b/Sources/AST/ASTDumper.swift
@@ -111,7 +111,13 @@ public class ASTDumper {
   func dump(_ structDeclaration: StructDeclaration) {
     writeNode("StructDeclaration") {
       self.dump(structDeclaration.identifier)
-
+      if !structDeclaration.conformances.isEmpty {
+        self.writeNode("Conforms to") {
+          for traitIdentifier in structDeclaration.conformances {
+            self.dump(traitIdentifier)
+          }
+        }
+      }
       for member in structDeclaration.members {
         self.dump(member)
       }

--- a/Sources/AST/ASTDumper.swift
+++ b/Sources/AST/ASTDumper.swift
@@ -65,6 +65,13 @@ public class ASTDumper {
     writeNode("ContractDeclaration") {
       self.dump(contractDeclaration.contractToken)
       self.dump(contractDeclaration.identifier)
+      if !contractDeclaration.conformances.isEmpty {
+        self.writeNode("Conforms to") {
+          for traitIdentifier in contractDeclaration.conformances {
+            self.dump(traitIdentifier)
+          }
+        }
+      }
       if !contractDeclaration.states.isEmpty {
         self.dump(contractDeclaration.states)
       }

--- a/Sources/AST/Declaration/ContractDeclaration.swift
+++ b/Sources/AST/Declaration/ContractDeclaration.swift
@@ -13,6 +13,7 @@ public struct ContractDeclaration: ASTNode {
 
   public var contractToken: Token
   public var identifier: Identifier
+  public var conformances: [Identifier]
   public var states: [TypeState]
   public var members: [ContractMember]
 
@@ -46,17 +47,19 @@ public struct ContractDeclaration: ASTNode {
     return EnumDeclaration(enumToken: enumToken, identifier: stateEnumIdentifier, type: intType, cases: cases)
   }
 
-  public init(contractToken: Token, identifier: Identifier, states: [TypeState], members: [ContractMember]) {
+  public init(contractToken: Token, identifier: Identifier, conformances: [Identifier], states: [TypeState], members: [ContractMember]) {
     self.identifier = identifier
     self.members = members
+    self.conformances = conformances
     self.states = states
     self.contractToken = contractToken
   }
 
   // MARK: - ASTNode
   public var description: String {
-    let stateText = states.map({ $0.description }).joined(separator: " ")
-    let headText = "contract \(identifier) \(stateText)"
+    let conformsText = conformances.map ({ $0.description }).joined(separator: ", ")
+    let stateText = states.map({ $0.description }).joined(separator: ", ")
+    let headText = "contract \(identifier): \(conformsText) \(stateText)"
     let memberText = members.map({ $0.description }).joined(separator: "\n")
     return "\(headText) {\(memberText)}"
   }

--- a/Sources/AST/Declaration/StructDeclaration.swift
+++ b/Sources/AST/Declaration/StructDeclaration.swift
@@ -11,6 +11,7 @@ import Lexer
 public struct StructDeclaration: ASTNode {
   public var structToken: Token
   public var identifier: Identifier
+  public var conformances: [Identifier]
   public var members: [StructMember]
 
   public var variableDeclarations: [VariableDeclaration] {
@@ -58,11 +59,11 @@ public struct StructDeclaration: ASTNode {
     return unassignedProperties.count == 0
   }
 
-  public init(structToken: Token, identifier: Identifier, members: [StructMember]) {
+  public init(structToken: Token, identifier: Identifier, conformances: [Identifier], members: [StructMember]) {
     self.structToken = structToken
     self.identifier = identifier
     self.members = members
-
+    self.conformances = conformances
     // Synthesize an initializer if none was defined.
     if shouldInitializerBeSynthesized {
       self.members.append(.specialDeclaration(synthesizeInitializer()))

--- a/Sources/Parser/Parser+Declaration.swift
+++ b/Sources/Parser/Parser+Declaration.swift
@@ -65,11 +65,15 @@ extension Parser {
   func parseStructDeclaration() throws -> StructDeclaration {
     let structToken = try consume(.struct, or: .badTopLevelDeclaration(at: latestSource))
     let identifier = try parseIdentifier()
+    var conformances: [Identifier] = []
+    if currentToken?.kind == .punctuation(.colon) {
+      conformances = try parseConformances()
+    }
     try consume(.punctuation(.openBrace), or: .leftBraceExpected(in: "struct declaration", at: latestSource))
     let members = try parseStructMembers(structIdentifier: identifier)
     try consume(.punctuation(.closeBrace), or: .rightBraceExpected(in: "struct declaration", at: latestSource))
 
-    return StructDeclaration(structToken: structToken, identifier: identifier, members: members)
+    return StructDeclaration(structToken: structToken, identifier: identifier, conformances: conformances, members: members)
   }
 
   func parseEnumDeclaration() throws -> EnumDeclaration {

--- a/Sources/Parser/Parser+Declaration.swift
+++ b/Sources/Parser/Parser+Declaration.swift
@@ -47,17 +47,19 @@ extension Parser {
   func parseContractDeclaration() throws -> ContractDeclaration {
     let contractToken = try consume(.contract, or: .badTopLevelDeclaration(at: latestSource))
     let identifier = try parseIdentifier()
-    let states: [TypeState]
+    var states: [TypeState] = []
+    var conformances: [Identifier] = []
+    if currentToken?.kind == .punctuation(.colon) {
+      conformances = try parseConformances()
+    }
     if currentToken?.kind == .punctuation(.openBracket) {
       states = try parseTypeStateGroup()
-    } else {
-      states = []
     }
     try consume(.punctuation(.openBrace), or: .leftBraceExpected(in: "contract declaration", at: latestSource))
     let members = try parseContractMembers(enclosingType: identifier.name)
     try consume(.punctuation(.closeBrace), or: .rightBraceExpected(in: "contract declaration", at: latestSource))
 
-    return ContractDeclaration(contractToken: contractToken, identifier: identifier, states: states, members: members)
+    return ContractDeclaration(contractToken: contractToken, identifier: identifier, conformances: conformances, states: states, members: members)
   }
 
   func parseStructDeclaration() throws -> StructDeclaration {

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -55,6 +55,7 @@ public class Parser {
         switch tld {
         case .contractDeclaration(let contract):
           environment.addContract(contract)
+          // TODO: Add conformances here 
           if contract.isStateful {
             environment.addEnum(contract.stateEnum)
           }

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -55,7 +55,7 @@ public class Parser {
         switch tld {
         case .contractDeclaration(let contract):
           environment.addContract(contract)
-          // TODO: Add conformances here 
+          // TODO: Add conformances here
           if contract.isStateful {
             environment.addEnum(contract.stateEnum)
           }
@@ -86,6 +86,7 @@ public class Parser {
           }
         case .structDeclaration(let structDeclaration):
           environment.addStruct(structDeclaration)
+          // TODO: Add conformances here 
 
         case .enumDeclaration(let enumDeclaration):
           environment.addEnum(enumDeclaration)

--- a/Sources/Parser/ParserError.swift
+++ b/Sources/Parser/ParserError.swift
@@ -54,6 +54,9 @@ extension Diagnostic {
   static func expectedBehaviourSeparator(at sourceLocation: SourceLocation) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected behaviour separator")
   }
+  static func expectedConformance(at sourceLocation: SourceLocation) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected conformance")
+  }
 
   // MARK: Statement
   static func expectedStatement(at sourceLocation: SourceLocation) -> Diagnostic {

--- a/Tests/ParserTests/conformance.flint
+++ b/Tests/ParserTests/conformance.flint
@@ -1,0 +1,44 @@
+// RUN: %flintc %s --dump-ast | %FileCheck %s --prefix CHECK-AST
+
+// CHECK-AST: ContractDeclaration
+// CHECK-AST:  identifier "C2"
+// CHECK-AST:  Conforms to
+// CHECK-AST:    "Ownable"
+// CHECK-AST:    "Burnable"
+// CHECK-AST:  States
+// CHECK-AST:    TypeState
+// CHECK-AST:      "State1"
+// CHECK-AST:    TypeState
+// CHECK-AST:      "State2"
+// CHECK-AST:    TypeState
+// CHECK-AST:      "State3"
+contract C2: Ownable, Burnable (State1, State2, State3) {}
+
+C2 @(any) :: (any) {
+  public init(){
+    become State1
+  }
+}
+
+// CHECK-AST: ContractDeclaration
+// CHECK-AST:  identifier "C3"
+// CHECK-AST:  Conforms to
+// CHECK-AST:    "Ownable"
+// CHECK-AST:    "Burnable"
+
+contract C3: Ownable, Burnable {}
+
+C3 :: (any) {
+  public init(){}
+}
+
+// CHECK-AST: ContractDeclaration
+// CHECK-AST:  identifier "C4"
+// CHECK-AST:  Conforms to
+// CHECK-AST:    "XSad999sads"
+
+contract C4: XSad999sads {}
+
+C4 :: (any) {
+  public init(){}
+}

--- a/Tests/ParserTests/conformance.flint
+++ b/Tests/ParserTests/conformance.flint
@@ -42,3 +42,23 @@ contract C4: XSad999sads {}
 C4 :: (any) {
   public init(){}
 }
+
+
+// CHECK-AST: StructDeclaration
+// CHECK-AST:  identifier "S1"
+// CHECK-AST:  Conforms to
+// CHECK-AST:    "Trait1"
+
+struct S1: Trait1 {
+}
+
+
+// CHECK-AST: StructDeclaration
+// CHECK-AST:  identifier "S2"
+// CHECK-AST:  Conforms to
+// CHECK-AST:    "Trait1"
+// CHECK-AST:    "Trait2"
+
+struct S2: Trait1, Trait2 {
+}
+

--- a/docs/grammar.abnf
+++ b/docs/grammar.abnf
@@ -9,7 +9,7 @@ topLevelDeclaration = contractDeclaration
                         / enumDeclaration;
 
 ; CONTRACTS
-contractDeclaration = %s"contract" SP identifier SP [identifierGroup] SP "{" *(WSP variableDeclaration CRLF) "}";
+contractDeclaration = %s"contract" SP identifier [":" WSP identifierList ] SP [identifierGroup] SP "{" *(WSP variableDeclaration CRLF) "}";
 
 ; VARIABLES
 variableDeclaration = [*(modifier SP)] SP (%s"var" / %s"let") SP identifier typeAnnotation [WSP "=" WSP expression];
@@ -41,7 +41,7 @@ enumCase        = %s"case" SP identifier
 eventDeclaration = "event" identifer "{" *(variableDeclaration) "}"
 
 ; STRUCTS
-structDeclaration = %s"struct" SP identifier SP "{" *(WSP structMember CRLF) "}";
+structDeclaration = %s"struct" SP identifier [":" WSP identifierList ] SP "{" *(WSP structMember CRLF) "}";
 
 structMember = variableDeclaration
                 / functionDeclaration
@@ -55,10 +55,11 @@ contractBehaviourMember = functionDeclaration
                             / fallbackDeclaration;
 
 ; ACCESS GROUPS
-stateGroup               = "@" identifierGroup;
+stateGroup              = "@" identifierGroup;
 callerCapabilityBinding = identifier WSP "<-";
 callerCapabilityGroup   = identifierGroup;
-identifierGroup           = "(" identifier *("," WSP identifier) ")";
+identifierGroup         = "(" identifierList ")";
+identifierList          = identifier *("," WSP identifier)
 
 ; FUNCTIONS + INITIALIZER + FALLBACK
 functionDeclaration    = functionHead SP identifier parameterList [returnType] codeBlock;


### PR DESCRIPTION
Adds onto #347

# Implementation Overview
Parser and AST now supports `: TraitName, TraitName` after structures and contracts 
# Notes

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Update docs/grammar.abnf if necessary
- [x] Include tests
- [x] Add `review wanted` label, remove "WIP" in PR title
