### PR TITLE
Trait specification structures

### DIFF
--- a/Sources/AST/ASTDumper.swift
+++ b/Sources/AST/ASTDumper.swift
@@ -117,7 +117,13 @@ public class ASTDumper {
   func dump(_ structDeclaration: StructDeclaration) {
     writeNode("StructDeclaration") {
       self.dump(structDeclaration.identifier)
-
+      if !structDeclaration.conformances.isEmpty {
+        self.writeNode("Conforms to") {
+          for traitIdentifier in structDeclaration.conformances {
+            self.dump(traitIdentifier)
+          }
+        }
+      }
       for member in structDeclaration.members {
         self.dump(member)
       }

--- a/Sources/AST/Declaration/StructDeclaration.swift
+++ b/Sources/AST/Declaration/StructDeclaration.swift
@@ -11,6 +11,7 @@ import Lexer
 public struct StructDeclaration: ASTNode {
   public var structToken: Token
   public var identifier: Identifier
+  public var conformances: [Identifier]
   public var members: [StructMember]
 
   public var variableDeclarations: [VariableDeclaration] {
@@ -58,11 +59,11 @@ public struct StructDeclaration: ASTNode {
     return unassignedProperties.count == 0
   }
 
-  public init(structToken: Token, identifier: Identifier, members: [StructMember]) {
+  public init(structToken: Token, identifier: Identifier, conformances: [Identifier], members: [StructMember]) {
     self.structToken = structToken
     self.identifier = identifier
     self.members = members
-
+    self.conformances = conformances
     // Synthesize an initializer if none was defined.
     if shouldInitializerBeSynthesized {
       self.members.append(.specialDeclaration(synthesizeInitializer()))

--- a/Sources/Parser/Parser+Declaration.swift
+++ b/Sources/Parser/Parser+Declaration.swift
@@ -70,11 +70,15 @@ extension Parser {
   func parseStructDeclaration() throws -> StructDeclaration {
     let structToken = try consume(.struct, or: .badTopLevelDeclaration(at: latestSource))
     let identifier = try parseIdentifier()
+    var conformances: [Identifier] = []
+    if currentToken?.kind == .punctuation(.colon) {
+      conformances = try parseConformances()
+    }
     try consume(.punctuation(.openBrace), or: .leftBraceExpected(in: "struct declaration", at: latestSource))
     let members = try parseStructMembers(structIdentifier: identifier)
     try consume(.punctuation(.closeBrace), or: .rightBraceExpected(in: "struct declaration", at: latestSource))
 
-    return StructDeclaration(structToken: structToken, identifier: identifier, members: members)
+    return StructDeclaration(structToken: structToken, identifier: identifier, conformances: conformances, members: members)
   }
 
   func parseEnumDeclaration() throws -> EnumDeclaration {

--- a/Sources/Parser/ParserError.swift
+++ b/Sources/Parser/ParserError.swift
@@ -54,6 +54,9 @@ extension Diagnostic {
   static func expectedBehaviourSeparator(at sourceLocation: SourceLocation) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected behaviour separator")
   }
+  static func expectedConformance(at sourceLocation: SourceLocation) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected conformance")
+  }
 
   // MARK: Statement
   static func expectedStatement(at sourceLocation: SourceLocation) -> Diagnostic {

--- a/Tests/ParserTests/conformance.flint
+++ b/Tests/ParserTests/conformance.flint
@@ -1,2 +1,19 @@
 // RUN: %flintc %s --dump-ast | %FileCheck %s --prefix CHECK-AST
 
+// CHECK-AST: StructDeclaration
+// CHECK-AST:  identifier "S1"
+// CHECK-AST:  Conforms to
+// CHECK-AST:    "Trait1"
+
+struct S1: Trait1 {
+}
+
+
+// CHECK-AST: StructDeclaration
+// CHECK-AST:  identifier "S2"
+// CHECK-AST:  Conforms to
+// CHECK-AST:    "Trait1"
+// CHECK-AST:    "Trait2"
+
+struct S2: Trait1, Trait2 {
+}

--- a/Tests/ParserTests/conformance.flint
+++ b/Tests/ParserTests/conformance.flint
@@ -1,0 +1,2 @@
+// RUN: %flintc %s --dump-ast | %FileCheck %s --prefix CHECK-AST
+

--- a/docs/grammar.abnf
+++ b/docs/grammar.abnf
@@ -51,7 +51,7 @@ traitMember = functionDeclaration
 eventDeclaration = "event" identifer "{" *(variableDeclaration) "}"
 
 ; STRUCTS
-structDeclaration = %s"struct" SP identifier SP "{" *(WSP structMember CRLF) "}";
+structDeclaration = %s"struct" SP identifier [":" WSP identifierList ] SP "{" *(WSP structMember CRLF) "}";
 
 structMember = variableDeclaration
                 / functionDeclaration
@@ -65,10 +65,11 @@ contractBehaviourMember = functionDeclaration
                             / fallbackDeclaration;
 
 ; ACCESS GROUPS
-stateGroup               = "@" identifierGroup;
+stateGroup              = "@" identifierGroup;
 callerCapabilityBinding = identifier WSP "<-";
 callerCapabilityGroup   = identifierGroup;
-identifierGroup           = "(" identifier *("," WSP identifier) ")";
+identifierGroup         = "(" identifierList ")";
+identifierList          = identifier *("," WSP identifier)
 
 ; FUNCTIONS + INITIALIZER + FALLBACK
 functionSignatureDeclaration    = functionHead SP identifier parameterList [returnType]


### PR DESCRIPTION
Fixes #353 

# Implementation Overview
Parser and AST now supports `: TraitName, TraitName` after structures

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Update docs/grammar.abnf if necessary
- [x] Include tests
- [x] Add `review wanted` label, remove "WIP" in PR title
