### PR TITLE
Caller functions

### DIFF
--- a/Sources/AST/ASTDumper.swift
+++ b/Sources/AST/ASTDumper.swift
@@ -310,6 +310,8 @@ public class ASTDumper {
       writeLine("Any")
     case .errorType:
       writeLine("Flint error type \(rawType.name)")
+    case .functionType(_):
+      writeLine("function type \(rawType.name)")
     }
   }
 

--- a/Sources/AST/Environment/Environment+Memory.swift
+++ b/Sources/AST/Environment/Environment+Memory.swift
@@ -18,6 +18,7 @@ extension Environment {
     case .inoutType(_): fatalError()
     case .any: return 0
     case .errorType: return 0
+    case .functionType(_): return 0
 
     case .stdlibType(let type):
       return types[type.rawValue]!.properties.reduce(0) { acc, element in

--- a/Sources/AST/Environment/Environment+Type.swift
+++ b/Sources/AST/Environment/Environment+Type.swift
@@ -13,6 +13,10 @@ extension Environment {
       return type
     }
 
+    if let function = types[enclosingType]?.functions[property]?.first! {
+      return .functionType(parameters: function.parameterTypes, result: function.resultType)
+    }
+
     guard let scopeContext = scopeContext, let type = scopeContext.type(for: property) else { return .errorType }
     return type
   }

--- a/Sources/AST/Environment/Environment.swift
+++ b/Sources/AST/Environment/Environment.swift
@@ -66,7 +66,7 @@ public struct Environment {
 
   /// The list of properties declared in a type which can be used as caller capabilities.
   func declaredCallerCapabilities(enclosingType: RawTypeIdentifier) -> [String] {
-    return types[enclosingType]!.properties.compactMap { key, value in
+    let properties: [String] = types[enclosingType]!.properties.compactMap { key, value in
       switch value.rawType {
       case .basicType(.address): return key
       case .fixedSizeArrayType(.basicType(.address), _): return key
@@ -75,6 +75,18 @@ public struct Environment {
       default: return nil
       }
     }
+    let functions: [String] = types[enclosingType]!.functions.compactMap { name, functions in
+      for function in functions {
+        if function.resultType == .basicType(.address), function.parameterTypes == [] {
+          return name
+        }
+        if function.resultType == .basicType(.bool), function.parameterTypes == [.basicType(.address)] {
+          return name
+        }
+      }
+      return nil
+    }
+    return properties + functions
   }
 
   public func getStateValue(_ state: Identifier, in contract: RawTypeIdentifier) -> Expression {

--- a/Sources/AST/TopLevelModule.swift
+++ b/Sources/AST/TopLevelModule.swift
@@ -111,7 +111,7 @@ public struct TopLevelModule: ASTNode {
         let keyParameter = Parameter(identifier: keyIdentifier, type: Type(inferredType: key, identifier: identifier), implicitToken: nil)
         let subExpression = SubscriptExpression(baseExpression: .identifier(identifier), indexExpression: .identifier(keyIdentifier), closeSquareBracketToken: Token(kind: .punctuation(.closeSquareBracket), sourceLocation: sourceLocation))
         return ([keyParameter], .subscriptExpression(subExpression), Type(inferredType: value, identifier: identifier))
-      case .stdlibType(_), .rangeType(_), .userDefinedType(_), .inoutType(_), .any, .errorType:
+      case .stdlibType(_), .rangeType(_), .userDefinedType(_), .inoutType(_), .functionType(_), .any, .errorType:
         return nil
     }
   }

--- a/Sources/AST/Type.swift
+++ b/Sources/AST/Type.swift
@@ -19,6 +19,7 @@ public indirect enum RawType: Equatable {
   case dictionaryType(key: RawType, value: RawType)
   case userDefinedType(RawTypeIdentifier)
   case inoutType(RawType)
+  case functionType(parameters: [RawType], result: RawType)
   case any
   case errorType
 
@@ -47,6 +48,7 @@ public indirect enum RawType: Equatable {
     case .inoutType(let rawType): return "$inout\(rawType.name)"
     case .any: return "Any"
     case .errorType: return "Flint$ErrorType"
+    case .functionType(let parameters, let result): return "(\(parameters.map{ $0.name }.joined(separator: ", ")) -> \(result)"
     }
   }
 
@@ -59,6 +61,7 @@ public indirect enum RawType: Equatable {
     case .dictionaryType(let key, let value): return key.isBuiltInType && value.isBuiltInType
     case .inoutType(let element): return element.isBuiltInType
     case .userDefinedType(_): return false
+    case .functionType(_): return false
     }
   }
 

--- a/Sources/IRGen/Runtime/IRWrapperFunction.swift
+++ b/Sources/IRGen/Runtime/IRWrapperFunction.swift
@@ -8,46 +8,46 @@
 import AST
 
 struct IRWrapperFunction {
- static let prefixHard = "flintAttemptCallWrapperHard$"
- static let prefixSoft = "flintAttemptCallWrapperSoft$"
- let function: IRFunction
+  static let prefixHard = "flintAttemptCallWrapperHard$"
+  static let prefixSoft = "flintAttemptCallWrapperSoft$"
+  let function: IRFunction
 
- func rendered(enclosingType: RawTypeIdentifier) -> String {
+  func rendered(enclosingType: RawTypeIdentifier) -> String {
    return rendered(enclosingType: enclosingType, hard: true) + "\n" + rendered(enclosingType: enclosingType, hard: false)
- }
+  }
 
- func rendered(enclosingType: RawTypeIdentifier, hard: Bool) -> String {
-   let callerCheck = IRCallerCapabilityChecks.init(callerCapabilities: function.callerCapabilities, revert: false)
-   let callerCode = callerCheck.rendered(enclosingType: enclosingType, environment: function.environment)
-   let functionCall = function.signature(withReturn: false)
+  func rendered(enclosingType: RawTypeIdentifier, hard: Bool) -> String {
+    let callerCheck = IRCallerCapabilityChecks.init(callerCapabilities: function.callerCapabilities, revert: false)
+    let callerCode = callerCheck.rendered(enclosingType: enclosingType, environment: function.environment)
+    let functionCall = function.signature(withReturn: false)
 
-   let invalidCall = hard ? "revert(0, 0)" : "\(IRFunction.returnVariableName) := 0"
+    let invalidCall = hard ? "revert(0, 0)" : "\(IRFunction.returnVariableName) := 0"
 
-   var validCall = hard ? "\(IRFunction.returnVariableName) := \(functionCall)" : "\(functionCall)\n    \(IRFunction.returnVariableName) := 1"
-   var returnSignature = "-> \(IRFunction.returnVariableName) "
-   if hard, function.functionDeclaration.isVoid {
-     validCall = functionCall
-     returnSignature = ""
-   }
-   if !hard, !function.functionDeclaration.isVoid {
-     validCall = "\(IRFunction.returnVariableName) := \(functionCall)\n    \(IRFunction.returnVariableName) := 1"
-   }
+    var validCall = hard ? "\(IRFunction.returnVariableName) := \(functionCall)" : "\(functionCall)\n    \(IRFunction.returnVariableName) := 1"
+    var returnSignature = "-> \(IRFunction.returnVariableName) "
+    if hard, function.functionDeclaration.isVoid {
+      validCall = functionCall
+      returnSignature = ""
+    }
+    if !hard, !function.functionDeclaration.isVoid {
+      validCall = "\(IRFunction.returnVariableName) := \(functionCall)\n    \(IRFunction.returnVariableName) := 1"
+    }
 
-   return """
-   function \(signature(hard))\(returnSignature){
-     \(callerCode.indented(by: 2))
-     switch \(callerCheck.variableName)
-     case 0 {
-       \(invalidCall)
-     }
-     default {
-       \(validCall)
-     }
-   }
-   """
- }
+    return """
+    function \(signature(hard))\(returnSignature){
+      \(callerCode.indented(by: 2))
+      switch \(callerCheck.variableName)
+      case 0 {
+        \(invalidCall)
+      }
+      default {
+        \(validCall)
+      }
+    }
+    """
+  }
 
- func signature(_ hard: Bool) -> String {
-   return "\(hard ? IRWrapperFunction.prefixHard : IRWrapperFunction.prefixSoft)\(function.signature(withReturn: false))"
- }
+  func signature(_ hard: Bool) -> String {
+    return "\(hard ? IRWrapperFunction.prefixHard : IRWrapperFunction.prefixSoft)\(function.signature(withReturn: false))"
+  }
 }

--- a/Tests/BehaviorTests/tests/caller/caller.flint
+++ b/Tests/BehaviorTests/tests/caller/caller.flint
@@ -12,6 +12,14 @@ Caller :: (any) {
     owners[lastIndex] = caller
     lastIndex += 1
   }
+
+  public func lastOwner() -> Address {
+    return owners[lastIndex - 1]
+  }
+
+  public func isPrimaryOwner(addr: Address) -> Bool {
+    return addr == owner
+  }
 }
 
 Caller :: (owners) {
@@ -32,6 +40,18 @@ Caller :: (owner) {
   public mutating func addOwner(newOwner: Address) {
     owners[lastIndex] = newOwner
     lastIndex += 1
+  }
+}
+
+Caller :: (lastOwner) {
+  public func lastCall() -> Bool {
+    return true
+  }
+}
+
+Caller :: (isPrimaryOwner) {
+  public func primaryCall() -> Bool {
+    return true
   }
 }
 

--- a/Tests/SemanticTests/caller_capability.flint
+++ b/Tests/SemanticTests/caller_capability.flint
@@ -8,9 +8,30 @@ Test :: caller <- (any) {
   public init() {
     self.owners[1] = caller
   }
+
+  public func isOwner(addr: Address) -> Bool {
+    var found: Bool = false
+    for let owner: Address in owners {
+      if owner == addr {
+        found = true
+      }
+    }
+    return found
+  }
+
+  public func getPrimaryOwner() -> Address {
+    return owners[1]
+  }
 }
 
 Test :: (owners) {
-  func bar() {
-  }
+  func bar() {}
+}
+
+Test :: (isOwner) {
+  func foo() {}
+}
+
+Test :: (getPrimaryOwner) {
+  func zoo() {}
 }

--- a/Tests/SemanticTests/undeclared_capability.flint
+++ b/Tests/SemanticTests/undeclared_capability.flint
@@ -4,9 +4,25 @@ contract Test {}
 
 Test :: caller <- (any) {
   public init() {}
-}
 
-Test :: (alice) { // expected-error {{Caller capability 'alice' is undefined in 'Test' or has incompatible type}}
-  func bar() {
+  public func isOwner(addr: Address, x: Int) -> Bool {
+    return true
+  }
+
+  public func isOwner2(addr: Address, x: Int) -> Int {
+    return 1
+  }
+
+
+  public func getPrimaryOwner(addr: Address) -> Address {
+    return addr
   }
 }
+
+Test :: (alice) {} // expected-error {{Caller capability 'alice' is undefined in 'Test' or has incompatible type}}
+
+Test :: (isOwner) {} // expected-error {{Caller capability 'isOwner' is undefined in 'Test' or has incompatible type}}
+
+Test :: (isOwner2) {} // expected-error {{Caller capability 'isOwner2' is undefined in 'Test' or has incompatible type}}
+
+Test :: (getPrimaryOwner) {} // expected-error {{Caller capability 'getPrimaryOwner' is undefined in 'Test' or has incompatible type}}


### PR DESCRIPTION
Fixes #356

# Implementation Overview
Allows caller capabilities to include functions of type `() -> Address` or `Address -> Bool`

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Update docs/grammar.abnf if necessary
- [x] Include tests
- [x] Add `review wanted` label, remove "WIP" in PR title
