### PR TITLE
Let parameters

### DIFF
--- a/Sources/AST/ASTPass/ASTPassContext.swift
+++ b/Sources/AST/ASTPass/ASTPassContext.swift
@@ -54,6 +54,12 @@ extension ASTPassContext {
     get { return self[AsLValueContextEntry.self] }
     set { self[AsLValueContextEntry.self] = newValue }
   }
+    
+  /// Whether the node currently being visited is inside a subscript i.e. 'a' in 'foo[a]'
+  public var isInSubscript: Bool {
+    get { return self[isInSubscriptEntry.self] ?? false }
+    set { self[isInSubscriptEntry.self] = newValue }
+  }
 
   /// Whether the node currently being visited is being the enclosing variable i.e. 'a' in 'a.foo'
   public var isEnclosing: Bool {
@@ -192,6 +198,10 @@ extension PassContextEntry {
 
 private struct EnvironmentContextEntry: PassContextEntry {
   typealias Value = Environment
+}
+
+private struct isInSubscriptEntry: PassContextEntry {
+  typealias Value = Bool
 }
 
 private struct AsLValueContextEntry: PassContextEntry {

--- a/Sources/AST/ASTVisitor/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor/ASTVisitor.swift
@@ -639,7 +639,9 @@ public struct ASTVisitor {
 
     processResult.element.baseExpression = processResult.combining(visit(processResult.element.baseExpression, passContext: processResult.passContext))
 
+    processResult.passContext.isInSubscript = true
     processResult.element.indexExpression = processResult.combining(visit(processResult.element.indexExpression, passContext: processResult.passContext))
+    processResult.passContext.isInSubscript = false
 
     let postProcessResult = pass.postProcess(subscriptExpression: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)

--- a/Sources/AST/ASTVisitor/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor/ASTVisitor.swift
@@ -636,13 +636,14 @@ public struct ASTVisitor {
 
   func visit(_ subscriptExpression: SubscriptExpression, passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression> {
     var processResult = pass.process(subscriptExpression: subscriptExpression, passContext: passContext)
-
+    let inSubscript = processResult.passContext.isInSubscript
+    
     processResult.element.baseExpression = processResult.combining(visit(processResult.element.baseExpression, passContext: processResult.passContext))
 
     processResult.passContext.isInSubscript = true
     processResult.element.indexExpression = processResult.combining(visit(processResult.element.indexExpression, passContext: processResult.passContext))
-    processResult.passContext.isInSubscript = false
-
+    processResult.passContext.isInSubscript = inSubscript
+    
     let postProcessResult = pass.postProcess(subscriptExpression: processResult.element, passContext: processResult.passContext)
     return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
   }

--- a/Sources/AST/Component/Parameter.swift
+++ b/Sources/AST/Component/Parameter.swift
@@ -35,7 +35,7 @@ public struct Parameter: ASTNode {
   }
 
   public var asVariableDeclaration: VariableDeclaration {
-    return VariableDeclaration(modifiers: [], declarationToken: nil, identifier: identifier, type: type)
+    return VariableDeclaration(modifiers: [], declarationToken: Token(kind: .let, sourceLocation: sourceLocation), identifier: identifier, type: type)
   }
 
   public init(identifier: Identifier, type: Type, implicitToken: Token?) {

--- a/Sources/AST/Environment/Environment+Type.swift
+++ b/Sources/AST/Environment/Environment+Type.swift
@@ -207,7 +207,7 @@ extension Environment {
       case .arrayType(let elementType): return elementType
       case .fixedSizeArrayType(let elementType, _): return elementType
       case .dictionaryType(_, let valueType): return valueType
-      default: fatalError()
+      default: return .errorType
       }
     case .literal(let literalToken): return type(ofLiteralToken: literalToken)
     case .arrayLiteral(let arrayLiteral):

--- a/Sources/AST/Type.swift
+++ b/Sources/AST/Type.swift
@@ -78,6 +78,13 @@ public indirect enum RawType: Equatable {
     return true
   }
 
+  public var isInout: Bool {
+    if case .inoutType(_) = self {
+      return true
+    }
+    return false
+  }
+
   /// Whether the type is compatible with the given type, i.e., if two expressions of those types can be used
   /// interchangeably.
   public func isCompatible(with otherType: RawType) -> Bool {

--- a/Sources/IRGen/Component/IRAssignment.swift
+++ b/Sources/IRGen/Component/IRAssignment.swift
@@ -16,7 +16,12 @@ struct IRAssignment {
 
     switch lhs {
     case .variableDeclaration(let variableDeclaration):
-      return "let \(Mangler.mangleName(variableDeclaration.identifier.name)) := \(rhsCode)"
+      let mangledName = Mangler.mangleName(variableDeclaration.identifier.name)
+      // Shadowed variables shouldn't be redeclared
+      if mangledName == rhsCode {
+        return ""
+      }
+      return "let \(mangledName) := \(rhsCode)"
     case .identifier(let identifier) where identifier.enclosingType == nil:
       return "\(identifier.name.mangled) := \(rhsCode)"
     default:

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Components.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Components.swift
@@ -62,7 +62,7 @@ extension SemanticAnalyzer {
 
         let scopeContext = passContext.scopeContext!
         if let variableDeclaration = scopeContext.declaration(for: identifier.name) {
-          if variableDeclaration.isConstant, asLValue {
+          if variableDeclaration.isConstant, !variableDeclaration.type.rawType.isInout, asLValue {
             // The variable is a constant but is attempted to be reassigned.
             diagnostics.append(.reassignmentToConstant(identifier, variableDeclaration.sourceLocation))
           }

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Components.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Components.swift
@@ -81,7 +81,7 @@ extension SemanticAnalyzer {
           // The property is not defined in the enclosing type.
           diagnostics.append(.useOfUndeclaredIdentifier(identifier))
           passContext.environment!.addUsedUndefinedVariable(identifier, enclosingType: enclosingType)
-        } else if asLValue {
+        } else if asLValue, !passContext.isInSubscript {
 
           if passContext.environment!.isPropertyConstant(identifier.name, enclosingType: enclosingType) {
             // Retrieve the source location of that property's declaration.

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Components.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Components.swift
@@ -62,7 +62,7 @@ extension SemanticAnalyzer {
 
         let scopeContext = passContext.scopeContext!
         if let variableDeclaration = scopeContext.declaration(for: identifier.name) {
-          if variableDeclaration.isConstant, !variableDeclaration.type.rawType.isInout, asLValue {
+          if variableDeclaration.isConstant, !variableDeclaration.type.rawType.isInout, asLValue, !passContext.isInSubscript {
             // The variable is a constant but is attempted to be reassigned.
             diagnostics.append(.reassignmentToConstant(identifier, variableDeclaration.sourceLocation))
           }

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Declarations.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Declarations.swift
@@ -275,7 +275,7 @@ extension SemanticAnalyzer {
 
   func isShadowing(_ first: VariableDeclaration, _ second: VariableDeclaration) -> Bool {
     return first.isConstant && second.isVariable &&
-      //!first.type.rawType.isInout &&
+      !first.type.rawType.isInout &&
       first.type.rawType == second.type.rawType
   }
 

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Declarations.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Declarations.swift
@@ -235,7 +235,8 @@ extension SemanticAnalyzer {
     }
 
     if passContext.inFunctionOrInitializer {
-      if let conflict = passContext.scopeContext!.declaration(for: variableDeclaration.identifier.name) {
+      if let conflict = passContext.scopeContext!.declaration(for: variableDeclaration.identifier.name),
+        !isShadowing(conflict, variableDeclaration) {
         diagnostics.append(.invalidRedeclaration(variableDeclaration.identifier, originalSource: conflict.identifier))
       }
 
@@ -270,6 +271,12 @@ extension SemanticAnalyzer {
     }
 
     return ASTPassResult(element: variableDeclaration, diagnostics: diagnostics, passContext: passContext)
+  }
+
+  func isShadowing(_ first: VariableDeclaration, _ second: VariableDeclaration) -> Bool {
+    return first.isConstant && second.isVariable &&
+      //!first.type.rawType.isInout &&
+      first.type.rawType == second.type.rawType
   }
 
   // MARK: Function

--- a/Tests/BehaviorTests/tests/array/array.flint
+++ b/Tests/BehaviorTests/tests/array/array.flint
@@ -104,6 +104,12 @@ Array :: (any) {
     return nestedDict[i][j]
   }
 
+  public func shadowing(i: Int) -> Int {
+    var i: Int = i
+    i += 20
+    return i
+  }
+
 }
 
 struct S {

--- a/Tests/SemanticTests/constants.flint
+++ b/Tests/SemanticTests/constants.flint
@@ -7,6 +7,8 @@ contract Constants {
   let d: Int = 3
   let e: Int // expected-note {{'e' is uninitialized}}
   var f: [Int] = []
+  let g: [Int] = []
+  var h: [Int] = []
 }
 
 Constants :: (any) {
@@ -29,6 +31,9 @@ Constants :: (any) {
 
     let x: Int = 2
     f[x] = 3
+
+    f[g[1] + c] = 2
+    f[d + g[c]] = 2
   }
 
   mutating func bar() {

--- a/Tests/SemanticTests/constants.flint
+++ b/Tests/SemanticTests/constants.flint
@@ -6,6 +6,7 @@ contract Constants {
   let c: Int = 2 + 3
   let d: Int = 3
   let e: Int // expected-note {{'e' is uninitialized}}
+  var f: [Int] = []
 }
 
 Constants :: (any) {
@@ -25,6 +26,9 @@ Constants :: (any) {
     }
 
     d = 4 // expected-error {{Cannot reassign to value: 'd' is a 'let' constant}}
+
+    let x: Int = 2
+    f[x] = 3
   }
 
   mutating func bar() {

--- a/Tests/SemanticTests/let_parameters.flint
+++ b/Tests/SemanticTests/let_parameters.flint
@@ -1,0 +1,27 @@
+// RUN: %flintc %s --verify
+
+struct S {
+  var x: Int = 0
+}
+
+contract LetParameter {}
+
+LetParameter :: (any) {
+  public init() {}
+
+  func foo(a: Int, b: Address) -> Bool {
+    a += 2 // expected-error {{Cannot reassign to value: 'a' is a 'let' constant}}
+    return true
+  }
+
+  func foo2(a: Int) -> Bool {
+    var a: Int = a
+    a += 2
+    return true
+  }
+
+
+  func bar(b: inout S) {
+    b.x = 20
+  }
+}


### PR DESCRIPTION
Fixes #324
Fixes #389 

# Implementation Overview
Having function parameters be variables has limited utility, optimizing for a line of code at the cost of confusion with inout and leading to code that can appear to do mutate the parameter while really mutating a local copy.

To emphasize the fact these values are unique copies and don't have the write-back semantics of inout, we should not allow parameters to be mutated.

If mutation of a function parameter is desired then the following can be used:
```
func foo(i: Int) {
  var i: Int = i
}
```
However, this shadowing is not necessarily an ideal fix and may indicate an anti-pattern. If you find yourself writing this to get it to compile it suggests that the method you are using is _probably_ not the best.
# Notes

# Checklist

- [x] Remove all TODOs, debug prints, whitespace changes
- [x] Update docs/grammar.abnf if necessary
- [x] Include tests
- [x] Add `review wanted` label, remove "WIP" in PR title
