### PR TITLE
Fix builds on swift 4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift
+FROM swift:4.2
 
 LABEL maintainer "Franklin Schrans <f.schrans@me.com>"
 

--- a/Sources/Lexer/Token.swift
+++ b/Sources/Lexer/Token.swift
@@ -52,7 +52,7 @@ public struct Token: Equatable, SourceEntity, CustomStringConvertible {
       case .var: return "var"
       case .let: return "let"
       case .func: return "func"
-      case .init: return "init"
+      case .`init`: return "init"
       case .fallback: return "fallback"
       case .self: return "self"
       case .implicit: return "implicit"


### PR DESCRIPTION
Init now requires quotes when in a switch case.