### PR TITLE
Lint and reformat

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,11 @@
+disabled_rules:
+  - identifier_name
+  - todo
+  - file_length
+  - type_body_length
+  - function_body_length
+  - cyclomatic_complexity
+  - large_tuple
+included:
+  - Sources
+  - Tests

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-all: 
-	swift build	
+all: lint
+	swift build
 	cp -r stdlib .build/debug/
 
-release:
+release: lint
 	swift build	-c release --static-swift-stdlib
 	cp -r stdlib .build/release/
 
@@ -13,4 +13,8 @@ zip: release
 
 test: release
 	cd Tests/BehaviorTests && ./compile_behavior_tests.sh
-	swift run -c release lite 
+	swift run -c release lite
+
+.PHONY: lint
+lint:
+	swiftlint lint

--- a/Sources/AST/ASTDumper.swift
+++ b/Sources/AST/ASTDumper.swift
@@ -23,7 +23,7 @@ public class ASTDumper {
     return output
   }
 
-  func writeNode(_ node: String, contents: (() -> ())? = nil) {
+  func writeNode(_ node: String, contents: (() -> Void)? = nil) {
     output += String(repeating: " ", count: indentation)
     output += "\(node) (\n"
     indentation += 2
@@ -347,7 +347,7 @@ public class ASTDumper {
         self.dump(rawType)
       }
     case .rangeType(let rawType):
-      writeNode("RangeType"){
+      writeNode("RangeType") {
         self.dump(rawType)
       }
     case .dictionaryType(key: let keyType, value: let valueType):
@@ -371,7 +371,7 @@ public class ASTDumper {
       writeLine("Any")
     case .errorType:
       writeLine("Flint error type \(rawType.name)")
-    case .functionType(_):
+    case .functionType:
       writeLine("function type \(rawType.name)")
     }
   }
@@ -409,7 +409,7 @@ public class ASTDumper {
       case .attemptExpression(let attemptExpression): self.dump(attemptExpression)
       case .sequence(let expressions): expressions.forEach { self.dump($0) }
       case .range(let rangeExpression): self.dump(rangeExpression)
-      case .rawAssembly(_): fatalError()
+      case .rawAssembly: fatalError()
       }
     }
   }
@@ -547,7 +547,7 @@ public class ASTDumper {
     }
   }
 
-  func dump(_ rangeExpression: RangeExpression){
+  func dump(_ rangeExpression: RangeExpression) {
     writeNode("RangeExpression") {
       self.dump(rangeExpression.initial)
       self.dump(rangeExpression.op)

--- a/Sources/AST/ASTPass/ASTPass.swift
+++ b/Sources/AST/ASTPass/ASTPass.swift
@@ -17,19 +17,23 @@ public protocol ASTPass {
   func process(topLevelModule: TopLevelModule, passContext: ASTPassContext) -> ASTPassResult<TopLevelModule>
 
   // MARK: Top Level Declarations
-  func process(topLevelDeclaration: TopLevelDeclaration, passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration>
-  func process(contractDeclaration: ContractDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration>
+  func process(topLevelDeclaration: TopLevelDeclaration,
+               passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration>
+  func process(contractDeclaration: ContractDeclaration,
+               passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration>
   func process(structDeclaration: StructDeclaration, passContext: ASTPassContext) -> ASTPassResult<StructDeclaration>
   func process(enumDeclaration: EnumDeclaration, passContext: ASTPassContext) -> ASTPassResult<EnumDeclaration>
   func process(traitDeclaration: TraitDeclaration, passContext: ASTPassContext) -> ASTPassResult<TraitDeclaration>
-  func process(contractBehaviorDeclaration: ContractBehaviorDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration>
+  func process(contractBehaviorDeclaration: ContractBehaviorDeclaration,
+               passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration>
 
   // MARK: Top Level Members
   func process(contractMember: ContractMember, passContext: ASTPassContext) -> ASTPassResult<ContractMember>
   func process(structMember: StructMember, passContext: ASTPassContext) -> ASTPassResult<StructMember>
   func process(enumCase: EnumMember, passContext: ASTPassContext) -> ASTPassResult<EnumMember>
   func process(traitMember: TraitMember, passContext: ASTPassContext) -> ASTPassResult<TraitMember>
-  func process(contractBehaviorMember: ContractBehaviorMember, passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorMember>
+  func process(contractBehaviorMember: ContractBehaviorMember,
+               passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorMember>
 
   // MARK: Statements
   func process(statement: Statement, passContext: ASTPassContext) -> ASTPassResult<Statement>
@@ -40,11 +44,15 @@ public protocol ASTPass {
   func process(forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement>
 
   // MARK: Declarations
-  func process(variableDeclaration: VariableDeclaration, passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration>
-  func process(functionDeclaration: FunctionDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration>
-  func process(functionSignatureDeclaration: FunctionSignatureDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionSignatureDeclaration>
+  func process(variableDeclaration: VariableDeclaration,
+               passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration>
+  func process(functionDeclaration: FunctionDeclaration,
+               passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration>
+  func process(functionSignatureDeclaration: FunctionSignatureDeclaration,
+               passContext: ASTPassContext) -> ASTPassResult<FunctionSignatureDeclaration>
   func process(specialDeclaration: SpecialDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration>
-  func process(specialSignatureDeclaration: SpecialSignatureDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialSignatureDeclaration>
+  func process(specialSignatureDeclaration: SpecialSignatureDeclaration,
+               passContext: ASTPassContext) -> ASTPassResult<SpecialSignatureDeclaration>
   func process(eventDeclaration: EventDeclaration, passContext: ASTPassContext) -> ASTPassResult<EventDeclaration>
 
   // MARK: Expression
@@ -54,8 +62,10 @@ public protocol ASTPass {
   func process(functionCall: FunctionCall, passContext: ASTPassContext) -> ASTPassResult<FunctionCall>
   func process(arrayLiteral: ArrayLiteral, passContext: ASTPassContext) -> ASTPassResult<ArrayLiteral>
   func process(rangeExpression: RangeExpression, passContext: ASTPassContext) -> ASTPassResult<RangeExpression>
-  func process(dictionaryLiteral: AST.DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<AST.DictionaryLiteral>
-  func process(subscriptExpression: SubscriptExpression, passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression>
+  func process(dictionaryLiteral: AST.DictionaryLiteral,
+               passContext: ASTPassContext) -> ASTPassResult<AST.DictionaryLiteral>
+  func process(subscriptExpression: SubscriptExpression,
+               passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression>
   func process(attemptExpression: AttemptExpression, passContext: ASTPassContext) -> ASTPassResult<AttemptExpression>
 
   // MARK: Components
@@ -73,22 +83,28 @@ public protocol ASTPass {
   // MARK: -
 
   // MARK: Modules
-  func postProcess(topLevelModule: TopLevelModule, passContext: ASTPassContext) -> ASTPassResult<TopLevelModule>
+  func postProcess(topLevelModule: TopLevelModule,
+                   passContext: ASTPassContext) -> ASTPassResult<TopLevelModule>
 
   // MARK: Top Level Declaration
-  func postProcess(topLevelDeclaration: TopLevelDeclaration, passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration>
-  func postProcess(contractDeclaration: ContractDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration>
-  func postProcess(structDeclaration: StructDeclaration, passContext: ASTPassContext) -> ASTPassResult<StructDeclaration>
+  func postProcess(topLevelDeclaration: TopLevelDeclaration,
+                   passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration>
+  func postProcess(contractDeclaration: ContractDeclaration,
+                   passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration>
+  func postProcess(structDeclaration: StructDeclaration,
+                   passContext: ASTPassContext) -> ASTPassResult<StructDeclaration>
   func postProcess(enumDeclaration: EnumDeclaration, passContext: ASTPassContext) -> ASTPassResult<EnumDeclaration>
   func postProcess(traitDeclaration: TraitDeclaration, passContext: ASTPassContext) -> ASTPassResult<TraitDeclaration>
-  func postProcess(contractBehaviorDeclaration: ContractBehaviorDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration>
+  func postProcess(contractBehaviorDeclaration: ContractBehaviorDeclaration,
+                   passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration>
 
   // MARK: Top Level Members
   func postProcess(contractMember: ContractMember, passContext: ASTPassContext) -> ASTPassResult<ContractMember>
   func postProcess(structMember: StructMember, passContext: ASTPassContext) -> ASTPassResult<StructMember>
   func postProcess(enumCase: EnumMember, passContext: ASTPassContext) -> ASTPassResult<EnumMember>
   func postProcess(traitMember: TraitMember, passContext: ASTPassContext) -> ASTPassResult<TraitMember>
-  func postProcess(contractBehaviorMember: ContractBehaviorMember, passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorMember>
+  func postProcess(contractBehaviorMember: ContractBehaviorMember,
+                   passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorMember>
 
   // MARK: Statements
   func postProcess(statement: Statement, passContext: ASTPassContext) -> ASTPassResult<Statement>
@@ -99,11 +115,16 @@ public protocol ASTPass {
   func postProcess(forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement>
 
   // MARK: Declarations
-  func postProcess(variableDeclaration: VariableDeclaration, passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration>
-  func postProcess(functionDeclaration: FunctionDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration>
-  func postProcess(functionSignatureDeclaration: FunctionSignatureDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionSignatureDeclaration>
-  func postProcess(specialDeclaration: SpecialDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration>
-  func postProcess(specialSignatureDeclaration: SpecialSignatureDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialSignatureDeclaration>
+  func postProcess(variableDeclaration: VariableDeclaration,
+                   passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration>
+  func postProcess(functionDeclaration: FunctionDeclaration,
+                   passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration>
+  func postProcess(functionSignatureDeclaration: FunctionSignatureDeclaration,
+                   passContext: ASTPassContext) -> ASTPassResult<FunctionSignatureDeclaration>
+  func postProcess(specialDeclaration: SpecialDeclaration,
+                   passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration>
+  func postProcess(specialSignatureDeclaration: SpecialSignatureDeclaration,
+                   passContext: ASTPassContext) -> ASTPassResult<SpecialSignatureDeclaration>
   func postProcess(eventDeclaration: EventDeclaration, passContext: ASTPassContext) -> ASTPassResult<EventDeclaration>
 
   // MARK: Expression
@@ -113,9 +134,12 @@ public protocol ASTPass {
   func postProcess(functionCall: FunctionCall, passContext: ASTPassContext) -> ASTPassResult<FunctionCall>
   func postProcess(arrayLiteral: ArrayLiteral, passContext: ASTPassContext) -> ASTPassResult<ArrayLiteral>
   func postProcess(rangeExpression: RangeExpression, passContext: ASTPassContext) -> ASTPassResult<RangeExpression>
-  func postProcess(dictionaryLiteral: DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<DictionaryLiteral>
-  func postProcess(subscriptExpression: SubscriptExpression, passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression>
-  func postProcess(attemptExpression: AttemptExpression, passContext: ASTPassContext) -> ASTPassResult<AttemptExpression>
+  func postProcess(dictionaryLiteral: DictionaryLiteral,
+                   passContext: ASTPassContext) -> ASTPassResult<DictionaryLiteral>
+  func postProcess(subscriptExpression: SubscriptExpression,
+                   passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression>
+  func postProcess(attemptExpression: AttemptExpression,
+                   passContext: ASTPassContext) -> ASTPassResult<AttemptExpression>
 
   // MARK: Components
   func postProcess(literalToken: Token, passContext: ASTPassContext) -> ASTPassResult<Token>
@@ -133,27 +157,32 @@ public protocol ASTPass {
 
 extension ASTPass {
   // MARK: Modules
-  public func process(topLevelModule: TopLevelModule, passContext: ASTPassContext) -> ASTPassResult<TopLevelModule>  {
+  public func process(topLevelModule: TopLevelModule, passContext: ASTPassContext) -> ASTPassResult<TopLevelModule> {
     return ASTPassResult(element: topLevelModule, diagnostics: [], passContext: passContext)
   }
 
   // MARK: Top Level Declaration
-  public func process(topLevelDeclaration: TopLevelDeclaration, passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration> {
+  public func process(topLevelDeclaration: TopLevelDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration> {
     return ASTPassResult(element: topLevelDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func process(contractDeclaration: ContractDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration> {
+  public func process(contractDeclaration: ContractDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration> {
     return ASTPassResult(element: contractDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func process(structDeclaration: StructDeclaration, passContext: ASTPassContext) -> ASTPassResult<StructDeclaration> {
+  public func process(structDeclaration: StructDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<StructDeclaration> {
     return ASTPassResult(element: structDeclaration, diagnostics: [], passContext: passContext)
   }
   public func process(enumDeclaration: EnumDeclaration, passContext: ASTPassContext) -> ASTPassResult<EnumDeclaration> {
     return ASTPassResult(element: enumDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func process(traitDeclaration: TraitDeclaration, passContext: ASTPassContext) -> ASTPassResult<TraitDeclaration> {
+  public func process(traitDeclaration: TraitDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<TraitDeclaration> {
     return ASTPassResult(element: traitDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func process(contractBehaviorDeclaration: ContractBehaviorDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration> {
+  public func process(contractBehaviorDeclaration: ContractBehaviorDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration> {
     return ASTPassResult(element: contractBehaviorDeclaration, diagnostics: [], passContext: passContext)
   }
 
@@ -170,7 +199,8 @@ extension ASTPass {
   public func process(traitMember: TraitMember, passContext: ASTPassContext) -> ASTPassResult<TraitMember> {
     return ASTPassResult(element: traitMember, diagnostics: [], passContext: passContext)
   }
-  public func process(contractBehaviorMember: ContractBehaviorMember, passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorMember> {
+  public func process(contractBehaviorMember: ContractBehaviorMember,
+                      passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorMember> {
     return ASTPassResult(element: contractBehaviorMember, diagnostics: [], passContext: passContext)
   }
 
@@ -195,22 +225,28 @@ extension ASTPass {
   }
 
   // MARK: Declarations
-  public func process(variableDeclaration: VariableDeclaration, passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration> {
+  public func process(variableDeclaration: VariableDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration> {
     return ASTPassResult(element: variableDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func process(functionDeclaration: FunctionDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
+  public func process(functionDeclaration: FunctionDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
     return ASTPassResult(element: functionDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func process(functionSignatureDeclaration: FunctionSignatureDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionSignatureDeclaration> {
+  public func process(functionSignatureDeclaration: FunctionSignatureDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<FunctionSignatureDeclaration> {
     return ASTPassResult(element: functionSignatureDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func process(specialDeclaration: SpecialDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
+  public func process(specialDeclaration: SpecialDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
     return ASTPassResult(element: specialDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func process(specialSignatureDeclaration: SpecialSignatureDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialSignatureDeclaration> {
+  public func process(specialSignatureDeclaration: SpecialSignatureDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<SpecialSignatureDeclaration> {
     return ASTPassResult(element: specialSignatureDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func process(eventDeclaration: EventDeclaration, passContext: ASTPassContext) -> ASTPassResult<EventDeclaration> {
+  public func process(eventDeclaration: EventDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<EventDeclaration> {
     return ASTPassResult(element: eventDeclaration, diagnostics: [], passContext: passContext)
   }
 
@@ -221,7 +257,8 @@ extension ASTPass {
   public func process(inoutExpression: InoutExpression, passContext: ASTPassContext) -> ASTPassResult<InoutExpression> {
     return ASTPassResult(element: inoutExpression, diagnostics: [], passContext: passContext)
   }
-  public func process(binaryExpression: BinaryExpression, passContext: ASTPassContext) -> ASTPassResult<BinaryExpression> {
+  public func process(binaryExpression: BinaryExpression,
+                      passContext: ASTPassContext) -> ASTPassResult<BinaryExpression> {
     return ASTPassResult(element: binaryExpression, diagnostics: [], passContext: passContext)
   }
   public func process(functionCall: FunctionCall, passContext: ASTPassContext) -> ASTPassResult<FunctionCall> {
@@ -230,16 +267,19 @@ extension ASTPass {
   public func process(rangeExpression: RangeExpression, passContext: ASTPassContext) -> ASTPassResult<RangeExpression> {
     return ASTPassResult(element: rangeExpression, diagnostics: [], passContext: passContext)
   }
-  public func process(subscriptExpression: SubscriptExpression, passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression> {
+  public func process(subscriptExpression: SubscriptExpression,
+                      passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression> {
     return ASTPassResult(element: subscriptExpression, diagnostics: [], passContext: passContext)
   }
-  public func process(attemptExpression: AttemptExpression, passContext: ASTPassContext) -> ASTPassResult<AttemptExpression> {
+  public func process(attemptExpression: AttemptExpression,
+                      passContext: ASTPassContext) -> ASTPassResult<AttemptExpression> {
     return ASTPassResult(element: attemptExpression, diagnostics: [], passContext: passContext)
   }
   public func process(arrayLiteral: ArrayLiteral, passContext: ASTPassContext) -> ASTPassResult<ArrayLiteral> {
     return ASTPassResult(element: arrayLiteral, diagnostics: [], passContext: passContext)
   }
-  public func process(dictionaryLiteral: DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<DictionaryLiteral> {
+  public func process(dictionaryLiteral: DictionaryLiteral,
+                      passContext: ASTPassContext) -> ASTPassResult<DictionaryLiteral> {
     return ASTPassResult(element: dictionaryLiteral, diagnostics: [], passContext: passContext)
   }
 
@@ -262,7 +302,8 @@ extension ASTPass {
   public func process(type: Type, passContext: ASTPassContext) -> ASTPassResult<Type> {
     return ASTPassResult(element: type, diagnostics: [], passContext: passContext)
   }
-  public func process(callerProtection: CallerProtection, passContext: ASTPassContext) -> ASTPassResult<CallerProtection> {
+  public func process(callerProtection: CallerProtection,
+                      passContext: ASTPassContext) -> ASTPassResult<CallerProtection> {
     return ASTPassResult(element: callerProtection, diagnostics: [], passContext: passContext)
   }
   public func process(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
@@ -271,39 +312,48 @@ extension ASTPass {
   public func process(conformance: Conformance, passContext: ASTPassContext) -> ASTPassResult<Conformance> {
     return ASTPassResult(element: conformance, diagnostics: [], passContext: passContext)
   }
-  public func process(functionArgument: FunctionArgument, passContext: ASTPassContext) -> ASTPassResult<FunctionArgument> {
+  public func process(functionArgument: FunctionArgument,
+                      passContext: ASTPassContext) -> ASTPassResult<FunctionArgument> {
     return ASTPassResult(element: functionArgument, diagnostics: [], passContext: passContext)
   }
 
   // MARK: -
 
   // MARK: Modules
-  public func postProcess(topLevelModule: TopLevelModule, passContext: ASTPassContext) -> ASTPassResult<TopLevelModule> {
+  public func postProcess(topLevelModule: TopLevelModule,
+                          passContext: ASTPassContext) -> ASTPassResult<TopLevelModule> {
     return ASTPassResult(element: topLevelModule, diagnostics: [], passContext: passContext)
   }
 
   // MARK: Top Level Declaration
-  public func postProcess(topLevelDeclaration: TopLevelDeclaration, passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration> {
+  public func postProcess(topLevelDeclaration: TopLevelDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration> {
     return ASTPassResult(element: topLevelDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(contractDeclaration: ContractDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration> {
+  public func postProcess(contractDeclaration: ContractDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration> {
     return ASTPassResult(element: contractDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(structDeclaration: StructDeclaration, passContext: ASTPassContext) -> ASTPassResult<StructDeclaration> {
+  public func postProcess(structDeclaration: StructDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<StructDeclaration> {
     return ASTPassResult(element: structDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(enumDeclaration: EnumDeclaration, passContext: ASTPassContext) -> ASTPassResult<EnumDeclaration> {
+  public func postProcess(enumDeclaration: EnumDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<EnumDeclaration> {
     return ASTPassResult(element: enumDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(traitDeclaration: TraitDeclaration, passContext: ASTPassContext) -> ASTPassResult<TraitDeclaration> {
+  public func postProcess(traitDeclaration: TraitDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<TraitDeclaration> {
     return ASTPassResult(element: traitDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(contractBehaviorDeclaration: ContractBehaviorDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration> {
+  public func postProcess(contractBehaviorDeclaration: ContractBehaviorDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration> {
     return ASTPassResult(element: contractBehaviorDeclaration, diagnostics: [], passContext: passContext)
   }
 
   // MARK: Top Level Members
-  public func postProcess(contractMember: ContractMember, passContext: ASTPassContext) -> ASTPassResult<ContractMember> {
+  public func postProcess(contractMember: ContractMember,
+                          passContext: ASTPassContext) -> ASTPassResult<ContractMember> {
     return ASTPassResult(element: contractMember, diagnostics: [], passContext: passContext)
   }
   public func postProcess(structMember: StructMember, passContext: ASTPassContext) -> ASTPassResult<StructMember> {
@@ -315,7 +365,8 @@ extension ASTPass {
   public func postProcess(traitMember: TraitMember, passContext: ASTPassContext) -> ASTPassResult<TraitMember> {
     return ASTPassResult(element: traitMember, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(contractBehaviorMember: ContractBehaviorMember, passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorMember> {
+  public func postProcess(contractBehaviorMember: ContractBehaviorMember,
+                          passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorMember> {
     return ASTPassResult(element: contractBehaviorMember, diagnostics: [], passContext: passContext)
   }
 
@@ -323,10 +374,12 @@ extension ASTPass {
   public func postProcess(statement: Statement, passContext: ASTPassContext) -> ASTPassResult<Statement> {
     return ASTPassResult(element: statement, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(returnStatement: ReturnStatement, passContext: ASTPassContext) -> ASTPassResult<ReturnStatement> {
+  public func postProcess(returnStatement: ReturnStatement,
+                          passContext: ASTPassContext) -> ASTPassResult<ReturnStatement> {
     return ASTPassResult(element: returnStatement, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(becomeStatement: BecomeStatement, passContext: ASTPassContext) -> ASTPassResult<BecomeStatement> {
+  public func postProcess(becomeStatement: BecomeStatement,
+                          passContext: ASTPassContext) -> ASTPassResult<BecomeStatement> {
     return ASTPassResult(element: becomeStatement, diagnostics: [], passContext: passContext)
   }
   public func postProcess(emitStatement: EmitStatement, passContext: ASTPassContext) -> ASTPassResult<EmitStatement> {
@@ -340,22 +393,28 @@ extension ASTPass {
   }
 
   // MARK: Declarations
-  public func postProcess(variableDeclaration: VariableDeclaration, passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration> {
+  public func postProcess(variableDeclaration: VariableDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration> {
     return ASTPassResult(element: variableDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(functionDeclaration: FunctionDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
+  public func postProcess(functionDeclaration: FunctionDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
     return ASTPassResult(element: functionDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(functionSignatureDeclaration: FunctionSignatureDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionSignatureDeclaration> {
+  public func postProcess(functionSignatureDeclaration: FunctionSignatureDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<FunctionSignatureDeclaration> {
     return ASTPassResult(element: functionSignatureDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(specialDeclaration: SpecialDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
+  public func postProcess(specialDeclaration: SpecialDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
     return ASTPassResult(element: specialDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(specialSignatureDeclaration: SpecialSignatureDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialSignatureDeclaration> {
+  public func postProcess(specialSignatureDeclaration: SpecialSignatureDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<SpecialSignatureDeclaration> {
     return ASTPassResult(element: specialSignatureDeclaration, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(eventDeclaration: EventDeclaration, passContext: ASTPassContext) -> ASTPassResult<EventDeclaration> {
+  public func postProcess(eventDeclaration: EventDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<EventDeclaration> {
     return ASTPassResult(element: eventDeclaration, diagnostics: [], passContext: passContext)
   }
 
@@ -363,28 +422,34 @@ extension ASTPass {
   public func postProcess(expression: Expression, passContext: ASTPassContext) -> ASTPassResult<Expression> {
     return ASTPassResult(element: expression, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(inoutExpression: InoutExpression, passContext: ASTPassContext) -> ASTPassResult<InoutExpression> {
+  public func postProcess(inoutExpression: InoutExpression,
+                          passContext: ASTPassContext) -> ASTPassResult<InoutExpression> {
     return ASTPassResult(element: inoutExpression, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(binaryExpression: BinaryExpression, passContext: ASTPassContext) -> ASTPassResult<BinaryExpression> {
+  public func postProcess(binaryExpression: BinaryExpression,
+                          passContext: ASTPassContext) -> ASTPassResult<BinaryExpression> {
     return ASTPassResult(element: binaryExpression, diagnostics: [], passContext: passContext)
   }
   public func postProcess(functionCall: FunctionCall, passContext: ASTPassContext) -> ASTPassResult<FunctionCall> {
     return ASTPassResult(element: functionCall, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(rangeExpression: RangeExpression, passContext: ASTPassContext) -> ASTPassResult<RangeExpression> {
+  public func postProcess(rangeExpression: RangeExpression,
+                          passContext: ASTPassContext) -> ASTPassResult<RangeExpression> {
     return ASTPassResult(element: rangeExpression, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(subscriptExpression: SubscriptExpression, passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression> {
+  public func postProcess(subscriptExpression: SubscriptExpression,
+                          passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression> {
     return ASTPassResult(element: subscriptExpression, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(attemptExpression: AttemptExpression, passContext: ASTPassContext) -> ASTPassResult<AttemptExpression> {
+  public func postProcess(attemptExpression: AttemptExpression,
+                          passContext: ASTPassContext) -> ASTPassResult<AttemptExpression> {
     return ASTPassResult(element: attemptExpression, diagnostics: [], passContext: passContext)
   }
   public func postProcess(arrayLiteral: ArrayLiteral, passContext: ASTPassContext) -> ASTPassResult<ArrayLiteral> {
     return ASTPassResult(element: arrayLiteral, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(dictionaryLiteral: DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<DictionaryLiteral> {
+  public func postProcess(dictionaryLiteral: DictionaryLiteral,
+                          passContext: ASTPassContext) -> ASTPassResult<DictionaryLiteral> {
     return ASTPassResult(element: dictionaryLiteral, diagnostics: [], passContext: passContext)
   }
 
@@ -398,7 +463,8 @@ extension ASTPass {
   public func postProcess(parameter: Parameter, passContext: ASTPassContext) -> ASTPassResult<Parameter> {
     return ASTPassResult(element: parameter, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(typeAnnotation: TypeAnnotation, passContext: ASTPassContext) -> ASTPassResult<TypeAnnotation> {
+  public func postProcess(typeAnnotation: TypeAnnotation,
+                          passContext: ASTPassContext) -> ASTPassResult<TypeAnnotation> {
     return ASTPassResult(element: typeAnnotation, diagnostics: [], passContext: passContext)
   }
   public func postProcess(identifier: Identifier, passContext: ASTPassContext) -> ASTPassResult<Identifier> {
@@ -407,7 +473,8 @@ extension ASTPass {
   public func postProcess(type: Type, passContext: ASTPassContext) -> ASTPassResult<Type> {
     return ASTPassResult(element: type, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(callerProtection: CallerProtection, passContext: ASTPassContext) -> ASTPassResult<CallerProtection> {
+  public func postProcess(callerProtection: CallerProtection,
+                          passContext: ASTPassContext) -> ASTPassResult<CallerProtection> {
     return ASTPassResult(element: callerProtection, diagnostics: [], passContext: passContext)
   }
   public func postProcess(typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
@@ -416,7 +483,8 @@ extension ASTPass {
   public func postProcess(conformance: Conformance, passContext: ASTPassContext) -> ASTPassResult<Conformance> {
     return ASTPassResult(element: conformance, diagnostics: [], passContext: passContext)
   }
-  public func postProcess(functionArgument: FunctionArgument, passContext: ASTPassContext) -> ASTPassResult<FunctionArgument> {
+  public func postProcess(functionArgument: FunctionArgument,
+                          passContext: ASTPassContext) -> ASTPassResult<FunctionArgument> {
     return ASTPassResult(element: functionArgument, diagnostics: [], passContext: passContext)
   }
 }

--- a/Sources/AST/ASTPass/ASTPassContext.swift
+++ b/Sources/AST/ASTPass/ASTPassContext.swift
@@ -31,7 +31,7 @@ public struct ASTPassContext {
   ///
   /// - Parameter updates: The modifications which should be applied to the new `ASTPassContext`.
   /// - Returns: The `ASTPassContext` applied with the `updates`.
-  public func withUpdates(updates: (inout ASTPassContext) -> ()) -> ASTPassContext {
+  public func withUpdates(updates: (inout ASTPassContext) -> Void) -> ASTPassContext {
     var copy = self
     updates(&copy)
     return copy
@@ -54,29 +54,29 @@ extension ASTPassContext {
     get { return self[AsLValueContextEntry.self] }
     set { self[AsLValueContextEntry.self] = newValue }
   }
-    
+
   /// Whether the node currently being visited is inside a subscript i.e. 'a' in 'foo[a]'
   public var isInSubscript: Bool {
-    get { return self[isInSubscriptEntry.self] ?? false }
-    set { self[isInSubscriptEntry.self] = newValue }
+    get { return self[IsInSubscriptEntry.self] ?? false }
+    set { self[IsInSubscriptEntry.self] = newValue }
   }
 
   /// Whether the node currently being visited is being the enclosing variable i.e. 'a' in 'a.foo'
   public var isEnclosing: Bool {
-    get { return self[isEnclosingEntry.self] ?? false }
-    set { self[isEnclosingEntry.self] = newValue }
+    get { return self[IsEnclosingEntry.self] ?? false }
+    set { self[IsEnclosingEntry.self] = newValue }
   }
 
   /// Whether the node currently being visited is within a become statement i.e. 'a' in 'become a'
   public var isInBecome: Bool {
-    get { return self[isInBecomeEntry.self] ?? false }
-    set { self[isInBecomeEntry.self] = newValue }
+    get { return self[IsInBecomeEntry.self] ?? false }
+    set { self[IsInBecomeEntry.self] = newValue }
   }
 
   /// Whether the node currently being visited is within a emit statement i.e. 'a' in 'emit a'
   public var isInEmit: Bool {
-    get { return self[isInEmitEntry.self] ?? false }
-    set { self[isInEmitEntry.self] = newValue }
+    get { return self[IsInEmitEntry.self] ?? false }
+    set { self[IsInEmitEntry.self] = newValue }
   }
 
   /// Contextual information used when visiting the state properties declared in a contract declaration.
@@ -200,7 +200,7 @@ private struct EnvironmentContextEntry: PassContextEntry {
   typealias Value = Environment
 }
 
-private struct isInSubscriptEntry: PassContextEntry {
+private struct IsInSubscriptEntry: PassContextEntry {
   typealias Value = Bool
 }
 
@@ -208,15 +208,15 @@ private struct AsLValueContextEntry: PassContextEntry {
   typealias Value = Bool
 }
 
-private struct isEnclosingEntry: PassContextEntry {
+private struct IsEnclosingEntry: PassContextEntry {
   typealias Value = Bool
 }
 
-private struct isInBecomeEntry: PassContextEntry {
+private struct IsInBecomeEntry: PassContextEntry {
   typealias Value = Bool
 }
 
-private struct isInEmitEntry: PassContextEntry {
+private struct IsInEmitEntry: PassContextEntry {
   typealias Value = Bool
 }
 

--- a/Sources/AST/ASTPass/ASTPassResult.swift
+++ b/Sources/AST/ASTPass/ASTPassResult.swift
@@ -24,7 +24,7 @@ public struct ASTPassResult<T> {
     self.diagnostics = diagnostics
     self.passContext = passContext
   }
-  
+
   /// Combines two processings of AST nodes, by merging contexts if required.
   ///
   /// - Parameters:
@@ -34,7 +34,7 @@ public struct ASTPassResult<T> {
   mutating func combining<S>(_ newPassResult: ASTPassResult<S>, mergingContexts: Bool = false) -> S {
     diagnostics.append(contentsOf: newPassResult.diagnostics)
 
-    passContext.storage.merge(newPassResult.passContext.storage, uniquingKeysWith: { lhs, rhs in
+    passContext.storage.merge(newPassResult.passContext.storage, uniquingKeysWith: { _, rhs in
       // Use the newest entry in case both contexts have values for the same key.
       return rhs
     })

--- a/Sources/AST/ASTVisitor/ASTVisitor.swift
+++ b/Sources/AST/ASTVisitor/ASTVisitor.swift
@@ -32,37 +32,51 @@ public struct ASTVisitor {
     }
 
     // Call `postProcess` on the node.
-    let postProcessResult = pass.postProcess(topLevelModule: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(topLevelModule: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   // MARK: Top Level Declarations
-  func visit(_ topLevelDeclaration: TopLevelDeclaration, passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration> {
+  func visit(_ topLevelDeclaration: TopLevelDeclaration,
+             passContext: ASTPassContext) -> ASTPassResult<TopLevelDeclaration> {
     var processResult = pass.process(topLevelDeclaration: topLevelDeclaration, passContext: passContext)
     switch processResult.element {
     case .contractBehaviorDeclaration(let contractBehaviorDeclaration):
-      processResult.element = .contractBehaviorDeclaration(processResult.combining(visit(contractBehaviorDeclaration, passContext: processResult.passContext)))
+      processResult.element = .contractBehaviorDeclaration(
+        processResult.combining(visit(contractBehaviorDeclaration, passContext: processResult.passContext)))
     case .contractDeclaration(let contractDeclaration):
-      processResult.element = .contractDeclaration(processResult.combining(visit(contractDeclaration, passContext: processResult.passContext)))
+      processResult.element = .contractDeclaration(
+        processResult.combining(visit(contractDeclaration, passContext: processResult.passContext)))
     case .structDeclaration(let structDeclaration):
-      processResult.element = .structDeclaration(processResult.combining(visit(structDeclaration, passContext: processResult.passContext)))
+      processResult.element = .structDeclaration(
+        processResult.combining(visit(structDeclaration, passContext: processResult.passContext)))
     case .enumDeclaration(let enumDeclaration):
-      processResult.element = .enumDeclaration(processResult.combining(visit(enumDeclaration, passContext: processResult.passContext)))
+      processResult.element = .enumDeclaration(
+        processResult.combining(visit(enumDeclaration, passContext: processResult.passContext)))
     case .traitDeclaration(let traitDeclaration):
-      processResult.element = .traitDeclaration(processResult.combining(visit(traitDeclaration, passContext: processResult.passContext)))
+      processResult.element = .traitDeclaration(
+        processResult.combining(visit(traitDeclaration, passContext: processResult.passContext)))
     }
 
-    let postProcessResult = pass.postProcess(topLevelDeclaration: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(topLevelDeclaration: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
-  func visit(_ contractDeclaration: ContractDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration> {
+  func visit(_ contractDeclaration: ContractDeclaration,
+             passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration> {
     var processResult = pass.process(contractDeclaration: contractDeclaration, passContext: passContext)
 
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier,
+                                                                     passContext: processResult.passContext))
 
-
-    processResult.passContext.contractStateDeclarationContext = ContractStateDeclarationContext(contractIdentifier: contractDeclaration.identifier)
+    processResult.passContext.contractStateDeclarationContext =
+      ContractStateDeclarationContext(contractIdentifier: contractDeclaration.identifier)
 
     processResult.element.conformances = processResult.element.conformances.map { conformance in
       return processResult.combining(visit(conformance, passContext: processResult.passContext))
@@ -78,16 +92,27 @@ public struct ASTVisitor {
 
     processResult.passContext.contractStateDeclarationContext = nil
 
-    let postProcessResult = pass.postProcess(contractDeclaration: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(contractDeclaration: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
-  func visit(_ contractBehaviorDeclaration: ContractBehaviorDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration> {
-    let declarationContext = ContractBehaviorDeclarationContext(contractIdentifier: contractBehaviorDeclaration.contractIdentifier, typeStates: contractBehaviorDeclaration.states, callerProtections: contractBehaviorDeclaration.callerProtections)
+  func visit(_ contractBehaviorDeclaration: ContractBehaviorDeclaration,
+             passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration> {
+    let declarationContext =
+      ContractBehaviorDeclarationContext(contractIdentifier: contractBehaviorDeclaration.contractIdentifier,
+                                         typeStates: contractBehaviorDeclaration.states,
+                                         callerProtections: contractBehaviorDeclaration.callerProtections)
 
     var localVariables = [VariableDeclaration]()
     if let callerBinding = contractBehaviorDeclaration.callerBinding {
-      localVariables.append(VariableDeclaration(modifiers: [], declarationToken: nil, identifier: callerBinding, type: Type(inferredType: .basicType(.address), identifier: callerBinding)))
+      localVariables.append(VariableDeclaration(modifiers: [],
+                                                declarationToken: nil,
+                                                identifier: callerBinding,
+                                                type: Type(inferredType: .basicType(.address),
+                                                           identifier: callerBinding)))
     }
 
     let scopeContext = ScopeContext(localVariables: localVariables)
@@ -98,14 +123,16 @@ public struct ASTVisitor {
 
     var processResult = pass.process(contractBehaviorDeclaration: contractBehaviorDeclaration, passContext: passContext)
 
-    processResult.element.contractIdentifier = processResult.combining(visit(processResult.element.contractIdentifier, passContext: processResult.passContext))
+    processResult.element.contractIdentifier =
+      processResult.combining(visit(processResult.element.contractIdentifier, passContext: processResult.passContext))
 
     processResult.element.states = processResult.element.states.map { typeState in
       return processResult.combining(visit(typeState, passContext: processResult.passContext))
     }
 
     if let callerBinding = processResult.element.callerBinding {
-      processResult.element.callerBinding = processResult.combining(visit(callerBinding, passContext: processResult.passContext))
+      processResult.element.callerBinding =
+        processResult.combining(visit(callerBinding, passContext: processResult.passContext))
     }
 
     processResult.element.callerProtections = processResult.element.callerProtections.map { callerProtection in
@@ -122,9 +149,12 @@ public struct ASTVisitor {
     processResult.passContext.contractBehaviorDeclarationContext = nil
     processResult.passContext.scopeContext = nil
 
-    let postProcessResult = pass.postProcess(contractBehaviorDeclaration: processResult.element, passContext: processResult.passContext)
+    let postProcessResult = pass.postProcess(contractBehaviorDeclaration: processResult.element,
+                                             passContext: processResult.passContext)
 
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ structDeclaration: StructDeclaration, passContext: ASTPassContext) -> ASTPassResult<StructDeclaration> {
@@ -138,7 +168,8 @@ public struct ASTVisitor {
       $0.scopeContext = scopeContext
     }
 
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+    processResult.element.identifier =
+      processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
 
     processResult.element.members = processResult.element.members.map { structMember in
       processResult.passContext.scopeContext = ScopeContext()
@@ -148,8 +179,11 @@ public struct ASTVisitor {
     processResult.passContext.structDeclarationContext = nil
     processResult.passContext.scopeContext = nil
 
-    let postProcessResult = pass.postProcess(structDeclaration: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult =
+      pass.postProcess(structDeclaration: processResult.element, passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ enumDeclaration: EnumDeclaration, passContext: ASTPassContext) -> ASTPassResult<EnumDeclaration> {
@@ -161,29 +195,36 @@ public struct ASTVisitor {
       $0.enumDeclarationContext = declarationContext
     }
 
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+    processResult.element.identifier =
+      processResult.combining(visit(processResult.element.identifier,
+                                    passContext: processResult.passContext))
 
     processResult.element.cases = processResult.element.cases.map { enumCase in
       processResult.passContext.scopeContext = ScopeContext()
       return processResult.combining(visit(enumCase, passContext: processResult.passContext))
     }
 
-
     processResult.passContext.enumDeclarationContext = nil
 
-    let postProcessResult = pass.postProcess(enumDeclaration: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult =
+      pass.postProcess(enumDeclaration: processResult.element,
+                       passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ traitDeclaration: TraitDeclaration, passContext: ASTPassContext) -> ASTPassResult<TraitDeclaration> {
     var processResult = pass.process(traitDeclaration: traitDeclaration, passContext: passContext)
 
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+    processResult.element.identifier =
+      processResult.combining(visit(processResult.element.identifier,
+                                    passContext: processResult.passContext))
 
     let traitDeclarationContext = TraitDeclarationContext(traitIdentifier: processResult.element.identifier)
     let traitScopeContext = ScopeContext()
 
-    processResult.passContext = processResult.passContext.withUpdates{
+    processResult.passContext = processResult.passContext.withUpdates {
       $0.traitDeclarationContext = traitDeclarationContext
       $0.scopeContext = traitScopeContext
     }
@@ -197,9 +238,12 @@ public struct ASTVisitor {
     processResult.passContext.traitDeclarationContext = nil
     processResult.passContext.scopeContext = nil
 
-    let postProcessResult = pass.postProcess(traitDeclaration: processResult.element, passContext: processResult.passContext)
+    let postProcessResult = pass.postProcess(traitDeclaration: processResult.element,
+                                             passContext: processResult.passContext)
 
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   // MARK: Top Level Members
@@ -207,14 +251,21 @@ public struct ASTVisitor {
     var processResult = pass.process(contractMember: contractMember, passContext: passContext)
 
     switch processResult.element {
-      case .variableDeclaration(let variableDeclaration):
-        processResult.element = .variableDeclaration(processResult.combining(visit(variableDeclaration, passContext: processResult.passContext)))
-      case .eventDeclaration(let eventDeclaration):
-        processResult.element = .eventDeclaration(processResult.combining(visit(eventDeclaration, passContext: processResult.passContext)))
+    case .variableDeclaration(let variableDeclaration):
+      processResult.element =
+        .variableDeclaration(processResult.combining(visit(variableDeclaration,
+                                                           passContext: processResult.passContext)))
+    case .eventDeclaration(let eventDeclaration):
+      processResult.element =
+        .eventDeclaration(processResult.combining(visit(eventDeclaration,
+                                                        passContext: processResult.passContext)))
     }
 
-    let postProcessResult = pass.postProcess(contractMember: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(contractMember: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
 
   }
 
@@ -223,24 +274,37 @@ public struct ASTVisitor {
 
     switch processResult.element {
     case .functionDeclaration(let functionDeclaration):
-      processResult.element = .functionDeclaration(processResult.combining(visit(functionDeclaration, passContext: processResult.passContext)))
+      processResult.element =
+        .functionDeclaration(processResult.combining(visit(functionDeclaration,
+                                                           passContext: processResult.passContext)))
     case .variableDeclaration(let variableDeclaration):
-      processResult.element = .variableDeclaration(processResult.combining(visit(variableDeclaration, passContext: processResult.passContext)))
+      processResult.element =
+        .variableDeclaration(processResult.combining(visit(variableDeclaration,
+                                                           passContext: processResult.passContext)))
     case .specialDeclaration(let specialDeclaration):
-      processResult.element = .specialDeclaration(processResult.combining(visit(specialDeclaration, passContext: processResult.passContext)))
+      processResult.element =
+        .specialDeclaration(processResult.combining(visit(specialDeclaration,
+                                                          passContext: processResult.passContext)))
     }
 
-    let postProcessResult = pass.postProcess(structMember: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(structMember: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ enumCase: EnumMember, passContext: ASTPassContext) -> ASTPassResult<EnumMember> {
     var processResult = pass.process(enumCase: enumCase, passContext: passContext)
 
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+    processResult.element.identifier =
+      processResult.combining(visit(processResult.element.identifier,
+                                    passContext: processResult.passContext))
 
     let postProcessResult = pass.postProcess(enumCase: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ traitMember: TraitMember, passContext: ASTPassContext) -> ASTPassResult<TraitMember> {
@@ -248,40 +312,62 @@ public struct ASTVisitor {
 
     switch processResult.element {
     case .functionDeclaration(let functionDeclaration):
-      processResult.element = .functionDeclaration(processResult.combining(visit(functionDeclaration, passContext: processResult.passContext)))
+      processResult.element =
+        .functionDeclaration(processResult.combining(visit(functionDeclaration,
+                                                           passContext: processResult.passContext)))
     case .functionSignatureDeclaration(let functionSignatureDeclaration):
-      processResult.element = .functionSignatureDeclaration(processResult.combining(visit(functionSignatureDeclaration, passContext: processResult.passContext)))
+      processResult.element = .
+        functionSignatureDeclaration(processResult.combining(visit(functionSignatureDeclaration,
+                                                                   passContext: processResult.passContext)))
     case .specialDeclaration(let specialDeclaration):
-      processResult.element = .specialDeclaration(processResult.combining(visit(specialDeclaration, passContext: processResult.passContext)))
+      processResult.element =
+        .specialDeclaration(processResult.combining(visit(specialDeclaration,
+                                                          passContext: processResult.passContext)))
     case .specialSignatureDeclaration(let specialSignatureDeclaration):
-      processResult.element = .specialSignatureDeclaration(processResult.combining(visit(specialSignatureDeclaration, passContext: processResult.passContext)))
+      processResult.element =
+        .specialSignatureDeclaration(processResult.combining(visit(specialSignatureDeclaration,
+                                                                   passContext: processResult.passContext)))
     case .contractBehaviourDeclaration(let contractBehaviourDeclaration):
-      processResult.element = .contractBehaviourDeclaration(processResult.combining(visit(contractBehaviourDeclaration, passContext: processResult.passContext)))
+      processResult.element =
+        .contractBehaviourDeclaration(processResult.combining(visit(contractBehaviourDeclaration,
+                                                                    passContext: processResult.passContext)))
     case .eventDeclaration(let eventDeclaration):
-      processResult.element = .eventDeclaration(processResult.combining(visit(eventDeclaration, passContext: processResult.passContext)))
+      processResult.element =
+        .eventDeclaration(processResult.combining(visit(eventDeclaration,
+                                                        passContext: processResult.passContext)))
     }
 
     let postProcessResult = pass.postProcess(traitMember: processResult.element, passContext: processResult.passContext)
 
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
-  func visit(_ contractBehaviorMember: ContractBehaviorMember, passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorMember> {
+  func visit(_ contractBehaviorMember: ContractBehaviorMember,
+             passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorMember> {
     var processResult = pass.process(contractBehaviorMember: contractBehaviorMember, passContext: passContext)
 
     switch processResult.element {
     case .functionDeclaration(let decl):
-      processResult.element = .functionDeclaration(processResult.combining(visit(decl, passContext: processResult.passContext)))
+      processResult.element =
+        .functionDeclaration(processResult.combining(visit(decl, passContext: processResult.passContext)))
     case .specialDeclaration(let decl):
-      processResult.element = .specialDeclaration(processResult.combining(visit(decl, passContext: processResult.passContext)))
+      processResult.element =
+        .specialDeclaration(processResult.combining(visit(decl, passContext: processResult.passContext)))
     case .functionSignatureDeclaration(let decl):
-      processResult.element = .functionSignatureDeclaration(processResult.combining(visit(decl, passContext: processResult.passContext)))
+      processResult.element =
+        .functionSignatureDeclaration(processResult.combining(visit(decl, passContext: processResult.passContext)))
     case .specialSignatureDeclaration(let decl):
-      processResult.element = .specialSignatureDeclaration(processResult.combining(visit(decl, passContext: processResult.passContext)))
+      processResult.element =
+        .specialSignatureDeclaration(processResult.combining(visit(decl, passContext: processResult.passContext)))
     }
 
-    let postProcessResult = pass.postProcess(contractBehaviorMember: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(contractBehaviorMember: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   // MARK: Statements
@@ -290,61 +376,86 @@ public struct ASTVisitor {
 
     switch processResult.element {
     case .expression(let expression):
-      processResult.element = .expression(processResult.combining(visit(expression, passContext: processResult.passContext)))
+      processResult.element =
+        .expression(processResult.combining(visit(expression, passContext: processResult.passContext)))
     case .returnStatement(let returnStatement):
-      processResult.element = .returnStatement(processResult.combining(visit(returnStatement, passContext: processResult.passContext)))
+      processResult.element =
+        .returnStatement(processResult.combining(visit(returnStatement, passContext: processResult.passContext)))
     case .becomeStatement(let becomeStatement):
-      processResult.element = .becomeStatement(processResult.combining(visit(becomeStatement, passContext: processResult.passContext)))
+      processResult.element =
+        .becomeStatement(processResult.combining(visit(becomeStatement, passContext: processResult.passContext)))
     case .ifStatement(let ifStatement):
-      processResult.element = .ifStatement(processResult.combining(visit(ifStatement, passContext: processResult.passContext)))
+      processResult.element =
+        .ifStatement(processResult.combining(visit(ifStatement, passContext: processResult.passContext)))
     case .forStatement(let forStatement):
-      processResult.element = .forStatement(processResult.combining(visit(forStatement, passContext: processResult.passContext)))
+      processResult.element =
+        .forStatement(processResult.combining(visit(forStatement, passContext: processResult.passContext)))
     case .emitStatement(let emitStatement):
-      processResult.element = .emitStatement(processResult.combining(visit(emitStatement, passContext: processResult.passContext)))
+      processResult.element =
+        .emitStatement(processResult.combining(visit(emitStatement, passContext: processResult.passContext)))
     }
 
     let postProcessResult = pass.postProcess(statement: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ returnStatement: ReturnStatement, passContext: ASTPassContext) -> ASTPassResult<ReturnStatement> {
     var processResult = pass.process(returnStatement: returnStatement, passContext: passContext)
 
     if let expression = processResult.element.expression {
-      processResult.element.expression = processResult.combining(visit(expression, passContext: processResult.passContext))
+      processResult.element.expression =
+        processResult.combining(visit(expression, passContext: processResult.passContext))
     }
 
-    let postProcessResult = pass.postProcess(returnStatement: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(returnStatement: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ becomeStatement: BecomeStatement, passContext: ASTPassContext) -> ASTPassResult<BecomeStatement> {
     var processResult = pass.process(becomeStatement: becomeStatement, passContext: passContext)
 
     processResult.passContext.isInBecome = true
-    processResult.element.expression = processResult.combining(visit(processResult.element.expression, passContext: processResult.passContext))
+    processResult.element.expression =
+      processResult.combining(visit(processResult.element.expression,
+                                    passContext: processResult.passContext))
     processResult.passContext.isInBecome = false
 
-    let postProcessResult = pass.postProcess(becomeStatement: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(becomeStatement: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ emitStatement: EmitStatement, passContext: ASTPassContext) -> ASTPassResult<EmitStatement> {
     var processResult = pass.process(emitStatement: emitStatement, passContext: passContext)
 
     processResult.passContext.isInEmit = true
-    processResult.element.expression = processResult.combining(visit(processResult.element.expression, passContext: processResult.passContext))
+    processResult.element.expression =
+      processResult.combining(visit(processResult.element.expression,
+                                    passContext: processResult.passContext))
     processResult.passContext.isInEmit = false
 
-    let postProcessResult = pass.postProcess(emitStatement: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult =
+      pass.postProcess(emitStatement: processResult.element,
+                       passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ ifStatement: IfStatement, passContext: ASTPassContext) -> ASTPassResult<IfStatement> {
     var passContext = passContext
     var processResult = pass.process(ifStatement: ifStatement, passContext: passContext)
 
-    processResult.element.condition = processResult.combining(visit(processResult.element.condition, passContext: processResult.passContext))
+    processResult.element.condition =
+      processResult.combining(visit(processResult.element.condition,
+                                    passContext: processResult.passContext))
 
     let scopeContext = passContext.scopeContext
     processResult.element.body = processResult.element.body.map { statement in
@@ -368,15 +479,19 @@ public struct ASTVisitor {
     processResult.passContext.scopeContext = scopeContext
 
     let postProcessResult = pass.postProcess(ifStatement: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ forStatement: ForStatement, passContext: ASTPassContext) -> ASTPassResult<ForStatement> {
     var passContext = passContext
     var processResult = pass.process(forStatement: forStatement, passContext: passContext)
 
-    processResult.element.variable = processResult.combining(visit(processResult.element.variable, passContext: processResult.passContext))
-    processResult.element.iterable = processResult.combining(visit(processResult.element.iterable, passContext: processResult.passContext))
+    processResult.element.variable = processResult.combining(visit(processResult.element.variable,
+                                                                   passContext: processResult.passContext))
+    processResult.element.iterable = processResult.combining(visit(processResult.element.iterable,
+                                                                   passContext: processResult.passContext))
 
     let scopeContext = passContext.scopeContext
     processResult.element.body = processResult.element.body.map { statement in
@@ -389,8 +504,11 @@ public struct ASTVisitor {
 
     processResult.passContext.scopeContext = scopeContext
 
-    let postProcessResult = pass.postProcess(forStatement: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(forStatement: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   // MARK: Declarations
@@ -405,7 +523,8 @@ public struct ASTVisitor {
       $0.scopeContext = scopeContext
     }
 
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier,
+                                                                     passContext: processResult.passContext))
 
     processResult.element.variableDeclarations = processResult.element.variableDeclarations.map { variableDeclaration in
       return processResult.combining(visit(variableDeclaration, passContext: processResult.passContext))
@@ -414,34 +533,46 @@ public struct ASTVisitor {
     processResult.passContext.eventDeclarationContext = nil
     processResult.passContext.scopeContext = nil
 
-    let postProcessResult = pass.postProcess(eventDeclaration: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(eventDeclaration: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
-  func visit(_ variableDeclaration: VariableDeclaration, passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration> {
+  func visit(_ variableDeclaration: VariableDeclaration,
+             passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration> {
     var processResult = pass.process(variableDeclaration: variableDeclaration, passContext: passContext)
 
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
-    processResult.element.type = processResult.combining(visit(processResult.element.type, passContext: processResult.passContext))
+    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier,
+                                                                     passContext: processResult.passContext))
+    processResult.element.type = processResult.combining(visit(processResult.element.type,
+                                                               passContext: processResult.passContext))
 
     if let assignedExpression = processResult.element.assignedExpression {
       let previousScopeContext = processResult.passContext.scopeContext
       // Create an empty scope context.
       processResult.passContext.scopeContext = ScopeContext()
       processResult.passContext.isPropertyDefaultAssignment = true
-      processResult.element.assignedExpression = processResult.combining(visit(assignedExpression, passContext: processResult.passContext))
+      processResult.element.assignedExpression = processResult.combining(visit(assignedExpression,
+                                                                               passContext: processResult.passContext))
       processResult.passContext.isPropertyDefaultAssignment = false
       processResult.passContext.scopeContext = previousScopeContext
     }
 
-    let postProcessResult = pass.postProcess(variableDeclaration: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(variableDeclaration: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
-  func visit(_ functionDeclaration: FunctionDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
+  func visit(_ functionDeclaration: FunctionDeclaration,
+             passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
     var processResult = pass.process(functionDeclaration: functionDeclaration, passContext: passContext)
 
-    processResult.element.signature = processResult.combining(visit(processResult.element.signature, passContext: processResult.passContext))
+    processResult.element.signature = processResult.combining(visit(processResult.element.signature,
+                                                                    passContext: processResult.passContext))
 
     let functionDeclarationContext = FunctionDeclarationContext(declaration: functionDeclaration)
 
@@ -455,36 +586,48 @@ public struct ASTVisitor {
 
     processResult.passContext.functionDeclarationContext = nil
 
-    let postProcessResult = pass.postProcess(functionDeclaration: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(functionDeclaration: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
-  func visit(_ functionSignatureDeclaration: FunctionSignatureDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionSignatureDeclaration> {
-    var processResult = pass.process(functionSignatureDeclaration: functionSignatureDeclaration, passContext: passContext)
+  func visit(_ functionSignatureDeclaration: FunctionSignatureDeclaration,
+             passContext: ASTPassContext) -> ASTPassResult<FunctionSignatureDeclaration> {
+    var processResult = pass.process(functionSignatureDeclaration: functionSignatureDeclaration,
+                                     passContext: passContext)
 
     processResult.element.attributes = processResult.element.attributes.map { attribute in
       return processResult.combining(visit(attribute, passContext: processResult.passContext))
     }
 
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier,
+                                                                     passContext: processResult.passContext))
 
     processResult.element.parameters = processResult.element.parameters.map { parameter in
       return processResult.combining(visit(parameter, passContext: processResult.passContext))
     }
 
     if let resultType = processResult.element.resultType {
-      processResult.element.resultType = processResult.combining(visit(resultType, passContext: processResult.passContext))
+      processResult.element.resultType = processResult.combining(visit(resultType,
+                                                                       passContext: processResult.passContext))
     }
 
-    let postProcessResult = pass.postProcess(functionSignatureDeclaration: processResult.element, passContext: processResult.passContext)
+    let postProcessResult = pass.postProcess(functionSignatureDeclaration: processResult.element,
+                                             passContext: processResult.passContext)
 
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
-  func visit(_ specialDeclaration: SpecialDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
+  func visit(_ specialDeclaration: SpecialDeclaration,
+             passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
     var processResult = pass.process(specialDeclaration: specialDeclaration, passContext: passContext)
 
-    processResult.element.signature = processResult.combining(visit(processResult.element.signature, passContext: processResult.passContext))
+    processResult.element.signature = processResult.combining(visit(processResult.element.signature,
+                                                                    passContext: processResult.passContext))
 
     let specialDeclarationContext = SpecialDeclarationContext(declaration: specialDeclaration)
     processResult.passContext.specialDeclarationContext = specialDeclarationContext
@@ -499,12 +642,16 @@ public struct ASTVisitor {
     processResult.element.body = newBody
     processResult.passContext.specialDeclarationContext = nil
 
-    let postProcessResult = pass.postProcess(specialDeclaration: processResult.element, passContext: processResult.passContext)
+    let postProcessResult = pass.postProcess(specialDeclaration: processResult.element,
+                                             passContext: processResult.passContext)
 
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
-  func visit(_ specialSignatureDeclaration: SpecialSignatureDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialSignatureDeclaration> {
+  func visit(_ specialSignatureDeclaration: SpecialSignatureDeclaration,
+             passContext: ASTPassContext) -> ASTPassResult<SpecialSignatureDeclaration> {
     var processResult = pass.process(specialSignatureDeclaration: specialSignatureDeclaration, passContext: passContext)
 
     processResult.element.attributes = processResult.element.attributes.map { attribute in
@@ -515,9 +662,12 @@ public struct ASTVisitor {
       return processResult.combining(visit(parameter, passContext: processResult.passContext))
     }
 
-    let postProcessResult = pass.postProcess(specialSignatureDeclaration: processResult.element, passContext: processResult.passContext)
+    let postProcessResult = pass.postProcess(specialSignatureDeclaration: processResult.element,
+                                             passContext: processResult.passContext)
 
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   // MARK: Expression
@@ -526,51 +676,71 @@ public struct ASTVisitor {
 
     switch processResult.element {
     case .inoutExpression(let inoutExpression):
-      processResult.element = .inoutExpression(processResult.combining(visit(inoutExpression, passContext: processResult.passContext)))
+      processResult.element = .inoutExpression(processResult.combining(visit(inoutExpression,
+                                                                             passContext: processResult.passContext)))
     case .binaryExpression(let binaryExpression):
-      processResult.element = .binaryExpression(processResult.combining(visit(binaryExpression, passContext: processResult.passContext)))
+      processResult.element = .binaryExpression(processResult.combining(visit(binaryExpression,
+                                                                              passContext: processResult.passContext)))
     case .bracketedExpression(let bracketedExpression):
       processResult.element = .bracketedExpression(BracketedExpression(
-        expression: processResult.combining(visit(bracketedExpression.expression, passContext: processResult.passContext)),
+        expression: processResult.combining(visit(bracketedExpression.expression,
+                                                  passContext: processResult.passContext)),
         openBracketToken: bracketedExpression.openBracketToken,
         closeBracketToken: bracketedExpression.closeBracketToken
       ))
     case .functionCall(let functionCall):
-      processResult.element = .functionCall(processResult.combining(visit(functionCall, passContext: processResult.passContext)))
+      processResult.element = .functionCall(processResult.combining(visit(functionCall,
+                                                                          passContext: processResult.passContext)))
     case .arrayLiteral(let arrayLiteral):
-      processResult.element = .arrayLiteral(processResult.combining(visit(arrayLiteral, passContext: processResult.passContext)))
+      processResult.element = .arrayLiteral(processResult.combining(visit(arrayLiteral,
+                                                                          passContext: processResult.passContext)))
     case .range(let rangeExpression):
-      processResult.element = .range(processResult.combining(visit(rangeExpression, passContext: processResult.passContext)))
+      processResult.element = .range(processResult.combining(visit(rangeExpression,
+                                                                   passContext: processResult.passContext)))
     case .dictionaryLiteral(let dictionaryLiteral):
-      processResult.element = .dictionaryLiteral(processResult.combining(visit(dictionaryLiteral, passContext: processResult.passContext)))
+      processResult.element = .dictionaryLiteral(processResult.combining(visit(dictionaryLiteral,
+                                                                               passContext: processResult.passContext)))
     case .identifier(let identifier):
-      processResult.element = .identifier(processResult.combining(visit(identifier, passContext: processResult.passContext)))
+      processResult.element = .identifier(processResult.combining(visit(identifier,
+                                                                        passContext: processResult.passContext)))
     case .literal(let literalToken):
-      processResult.element = .literal(processResult.combining(visit(literalToken, passContext: processResult.passContext)))
-    case .self(_): break
+      processResult.element = .literal(processResult.combining(visit(literalToken,
+                                                                     passContext: processResult.passContext)))
+    case .self: break
     case .variableDeclaration(let variableDeclaration):
-      processResult.element = .variableDeclaration(processResult.combining(visit(variableDeclaration, passContext: processResult.passContext)))
+      processResult.element =
+        .variableDeclaration(processResult.combining(visit(variableDeclaration,
+                                                           passContext: processResult.passContext)))
     case .subscriptExpression(let subscriptExpression):
-      processResult.element = .subscriptExpression(processResult.combining(visit(subscriptExpression, passContext: processResult.passContext)))
+      processResult.element =
+        .subscriptExpression(processResult.combining(visit(subscriptExpression,
+                                                           passContext: processResult.passContext)))
     case .attemptExpression(let attemptExpression):
-      processResult.element = .attemptExpression(processResult.combining(visit(attemptExpression, passContext: processResult.passContext)))
+      processResult.element = .attemptExpression(processResult.combining(visit(attemptExpression,
+                                                                               passContext: processResult.passContext)))
     case .sequence(let elements):
       processResult.element = .sequence(elements.map { element in
         return processResult.combining(visit(element, passContext: processResult.passContext))
       })
-    case .rawAssembly(_): break
+    case .rawAssembly: break
     }
 
     let postProcessResult = pass.postProcess(expression: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ inoutExpression: InoutExpression, passContext: ASTPassContext) -> ASTPassResult<InoutExpression> {
     var processResult = pass.process(inoutExpression: inoutExpression, passContext: passContext)
-    processResult.element.expression = processResult.combining(visit(processResult.element.expression, passContext: processResult.passContext))
+    processResult.element.expression = processResult.combining(visit(processResult.element.expression,
+                                                                     passContext: processResult.passContext))
 
-    let postProcessResult = pass.postProcess(inoutExpression: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(inoutExpression: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ binaryExpression: BinaryExpression, passContext: ASTPassContext) -> ASTPassResult<BinaryExpression> {
@@ -584,33 +754,41 @@ public struct ASTVisitor {
     if case .punctuation(.dot) = binaryExpression.op.kind {
       processResult.passContext.isEnclosing = true
     }
-    processResult.element.lhs = processResult.combining(visit(processResult.element.lhs, passContext: processResult.passContext))
+    processResult.element.lhs = processResult.combining(visit(processResult.element.lhs,
+                                                              passContext: processResult.passContext))
 
     if !binaryExpression.isExplicitPropertyAccess {
       processResult.passContext.asLValue = false
     }
     processResult.passContext.isEnclosing = false
 
-    switch passContext.environment!.type(of: processResult.element.lhs, enclosingType: passContext.enclosingTypeIdentifier!.name, scopeContext: passContext.scopeContext!) {
-    case .arrayType(_), .fixedSizeArrayType(_), .dictionaryType(_):
+    switch passContext.environment!.type(of: processResult.element.lhs,
+                                         enclosingType: passContext.enclosingTypeIdentifier!.name,
+                                         scopeContext: passContext.scopeContext!) {
+    case .arrayType, .fixedSizeArrayType, .dictionaryType:
       break
     default:
       if case .punctuation(let punctuation) = binaryExpression.op.kind, punctuation.isAssignment {
         processResult.passContext.inAssignment = true
       }
-      processResult.element.rhs = processResult.combining(visit(processResult.element.rhs, passContext: processResult.passContext))
+      processResult.element.rhs = processResult.combining(visit(processResult.element.rhs,
+                                                                passContext: processResult.passContext))
       processResult.passContext.inAssignment = false // Allowed as nested assignments do not exist.
     }
 
-    let postProcessResult = pass.postProcess(binaryExpression: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(binaryExpression: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ functionCall: FunctionCall, passContext: ASTPassContext) -> ASTPassResult<FunctionCall> {
     var processResult = pass.process(functionCall: functionCall, passContext: passContext)
 
     processResult.passContext.isFunctionCall = true
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier,
+                                                                     passContext: processResult.passContext))
     processResult.passContext.isFunctionCall = false
 
     processResult.element.arguments = processResult.element.arguments.map { argument in
@@ -619,9 +797,12 @@ public struct ASTVisitor {
       return processResult.combining(x)
     }
 
-    let postProcessResult = pass.postProcess(functionCall: processResult.element, passContext: processResult.passContext)
+    let postProcessResult = pass.postProcess(functionCall: processResult.element,
+                                             passContext: processResult.passContext)
 
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ rangeExpression: RangeExpression, passContext: ASTPassContext) -> ASTPassResult<RangeExpression> {
@@ -631,30 +812,43 @@ public struct ASTVisitor {
     element.bound = processResult.combining(visit(element.bound, passContext: processResult.passContext))
 
     let postProcessResult = pass.postProcess(rangeExpression: element, passContext: processResult.passContext)
-    return ASTPassResult(element: element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
-  func visit(_ subscriptExpression: SubscriptExpression, passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression> {
+  func visit(_ subscriptExpression: SubscriptExpression,
+             passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression> {
     var processResult = pass.process(subscriptExpression: subscriptExpression, passContext: passContext)
     let inSubscript = processResult.passContext.isInSubscript
-    
-    processResult.element.baseExpression = processResult.combining(visit(processResult.element.baseExpression, passContext: processResult.passContext))
+
+    processResult.element.baseExpression = processResult.combining(visit(processResult.element.baseExpression,
+                                                                         passContext: processResult.passContext))
 
     processResult.passContext.isInSubscript = true
-    processResult.element.indexExpression = processResult.combining(visit(processResult.element.indexExpression, passContext: processResult.passContext))
+    processResult.element.indexExpression = processResult.combining(visit(processResult.element.indexExpression,
+                                                                          passContext: processResult.passContext))
     processResult.passContext.isInSubscript = inSubscript
-    
-    let postProcessResult = pass.postProcess(subscriptExpression: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+
+    let postProcessResult = pass.postProcess(subscriptExpression: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ attemptExpression: AttemptExpression, passContext: ASTPassContext) -> ASTPassResult<AttemptExpression> {
     var processResult = pass.process(attemptExpression: attemptExpression, passContext: passContext)
 
-    processResult.element.functionCall = processResult.combining(visit(processResult.element.functionCall, passContext: processResult.passContext))
+    processResult.element.functionCall =
+      processResult.combining(visit(processResult.element.functionCall,
+                                    passContext: processResult.passContext))
 
-    let postProcessResult = pass.postProcess(attemptExpression: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(attemptExpression: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ arrayLiteral: ArrayLiteral, passContext: ASTPassContext) -> ASTPassResult<ArrayLiteral> {
@@ -664,8 +858,11 @@ public struct ASTVisitor {
       return processResult.combining(visit(element, passContext: processResult.passContext))
     }
 
-    let postProcessResult = pass.postProcess(arrayLiteral: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(arrayLiteral: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ dictionaryLiteral: DictionaryLiteral, passContext: ASTPassContext) -> ASTPassResult<DictionaryLiteral> {
@@ -678,38 +875,52 @@ public struct ASTVisitor {
       return element
     }
 
-    let postProcessResult = pass.postProcess(dictionaryLiteral: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(dictionaryLiteral: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
-  // Mark: Components
+  // MARK: Components
   func visit(_ attribute: Attribute, passContext: ASTPassContext) -> ASTPassResult<Attribute> {
     let processResult = pass.process(attribute: attribute, passContext: passContext)
 
     let postProcessResult = pass.postProcess(attribute: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ parameter: Parameter, passContext: ASTPassContext) -> ASTPassResult<Parameter> {
     var processResult = pass.process(parameter: parameter, passContext: passContext)
-    processResult.element.type = processResult.combining(visit(processResult.element.type, passContext: processResult.passContext))
+    processResult.element.type = processResult.combining(visit(processResult.element.type,
+                                                               passContext: processResult.passContext))
 
     let postProcessResult = pass.postProcess(parameter: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ typeAnnotation: TypeAnnotation, passContext: ASTPassContext) -> ASTPassResult<TypeAnnotation> {
     var processResult = pass.process(typeAnnotation: typeAnnotation, passContext: passContext)
-    processResult.element.type = processResult.combining(visit(processResult.element.type, passContext: processResult.passContext))
+    processResult.element.type = processResult.combining(visit(processResult.element.type,
+                                                               passContext: processResult.passContext))
 
-    let postProcessResult = pass.postProcess(typeAnnotation: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(typeAnnotation: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ identifier: Identifier, passContext: ASTPassContext) -> ASTPassResult<Identifier> {
     let processResult = pass.process(identifier: identifier, passContext: passContext)
     let postProcessResult = pass.postProcess(identifier: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ type: Type, passContext: ASTPassContext) -> ASTPassResult<Type> {
@@ -720,50 +931,69 @@ public struct ASTVisitor {
     }
 
     let postProcessResult = pass.postProcess(type: processResult.element, passContext: passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ callerProtection: CallerProtection, passContext: ASTPassContext) -> ASTPassResult<CallerProtection> {
     var processResult = pass.process(callerProtection: callerProtection, passContext: passContext)
 
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier,
+                                                                     passContext: processResult.passContext))
 
-    let postProcessResult = pass.postProcess(callerProtection: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(callerProtection: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ typeState: TypeState, passContext: ASTPassContext) -> ASTPassResult<TypeState> {
     var processResult = pass.process(typeState: typeState, passContext: passContext)
 
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier,
+                                                                     passContext: processResult.passContext))
 
     let postProcessResult = pass.postProcess(typeState: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ conformance: Conformance, passContext: ASTPassContext) -> ASTPassResult<Conformance> {
     var processResult = pass.process(conformance: conformance, passContext: passContext)
 
-    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier, passContext: processResult.passContext))
+    processResult.element.identifier = processResult.combining(visit(processResult.element.identifier,
+                                                                     passContext: processResult.passContext))
 
     let postProcessResult = pass.postProcess(conformance: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 
   func visit(_ literalToken: Token, passContext: ASTPassContext) -> ASTPassResult<Token> {
     let processResult = pass.process(literalToken: literalToken, passContext: passContext)
     let postProcessResult = pass.process(literalToken: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: postProcessResult.diagnostics, passContext: passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: postProcessResult.diagnostics,
+                         passContext: passContext)
   }
 
   func visit(_ functionArgument: FunctionArgument, passContext: ASTPassContext) -> ASTPassResult<FunctionArgument> {
     var processResult = pass.process(functionArgument: functionArgument, passContext: passContext)
     if let identifier = processResult.element.identifier {
-      processResult.element.identifier = processResult.combining(visit(identifier, passContext: processResult.passContext))
+      processResult.element.identifier = processResult.combining(visit(identifier,
+                                                                       passContext: processResult.passContext))
     }
-    processResult.element.expression = processResult.combining(visit(processResult.element.expression, passContext: processResult.passContext))
+    processResult.element.expression = processResult.combining(visit(processResult.element.expression,
+                                                                     passContext: processResult.passContext))
 
-    let postProcessResult = pass.postProcess(functionArgument: processResult.element, passContext: processResult.passContext)
-    return ASTPassResult(element: postProcessResult.element, diagnostics: processResult.diagnostics + postProcessResult.diagnostics, passContext: postProcessResult.passContext)
+    let postProcessResult = pass.postProcess(functionArgument: processResult.element,
+                                             passContext: processResult.passContext)
+    return ASTPassResult(element: postProcessResult.element,
+                         diagnostics: processResult.diagnostics + postProcessResult.diagnostics,
+                         passContext: postProcessResult.passContext)
   }
 }

--- a/Sources/AST/ASTVisitor/ASTVisitorContext.swift
+++ b/Sources/AST/ASTVisitor/ASTVisitorContext.swift
@@ -38,7 +38,7 @@ public struct StructDeclarationContext {
 public struct EventDeclarationContext {
   public var eventIdentifier: Identifier
 
-  public init(eventIdentifier: Identifier){
+  public init(eventIdentifier: Identifier) {
     self.eventIdentifier = eventIdentifier
   }
 }

--- a/Sources/AST/Component/Attribute.swift
+++ b/Sources/AST/Component/Attribute.swift
@@ -15,7 +15,11 @@ public struct Attribute: ASTNode {
   var identifierToken: Token
 
   public init?(atToken: Token, identifierToken: Token) {
-    guard case .identifier(let attribute) = identifierToken.kind, let kind = Kind(rawValue: attribute) else { return nil }
+    guard case .identifier(let attribute) = identifierToken.kind,
+      let kind = Kind(rawValue: attribute) else {
+        return nil
+    }
+
     self.kind = kind
     self.atToken = atToken
     self.identifierToken = identifierToken

--- a/Sources/AST/Component/Conformance.swift
+++ b/Sources/AST/Component/Conformance.swift
@@ -25,4 +25,3 @@ public struct Conformance: ASTNode {
     return identifier.sourceLocation
   }
 }
-

--- a/Sources/AST/Component/Identifier.swift
+++ b/Sources/AST/Component/Identifier.swift
@@ -10,7 +10,7 @@ import Lexer
 /// An identifier for a contract, struct, variable, or function.
 public struct Identifier: Hashable, ASTNode {
   public var identifierToken: Token
-  public var enclosingType: String? = nil
+  public var enclosingType: String?
 
   public var name: String {
     if case .self = identifierToken.kind {

--- a/Sources/AST/Component/Parameter.swift
+++ b/Sources/AST/Component/Parameter.swift
@@ -35,7 +35,10 @@ public struct Parameter: ASTNode {
   }
 
   public var asVariableDeclaration: VariableDeclaration {
-    return VariableDeclaration(modifiers: [], declarationToken: Token(kind: .let, sourceLocation: sourceLocation), identifier: identifier, type: type)
+    return VariableDeclaration(modifiers: [],
+                               declarationToken: Token(kind: .let, sourceLocation: sourceLocation),
+                               identifier: identifier,
+                               type: type)
   }
 
   public init(identifier: Identifier, type: Type, implicitToken: Token?) {

--- a/Sources/AST/Component/TypeState.swift
+++ b/Sources/AST/Component/TypeState.swift
@@ -33,4 +33,3 @@ public struct TypeState: ASTNode {
     return identifier.sourceLocation
   }
 }
-

--- a/Sources/AST/Declaration/ContractBehaviorDeclaration.swift
+++ b/Sources/AST/Declaration/ContractBehaviorDeclaration.swift
@@ -17,7 +17,12 @@ public struct ContractBehaviorDeclaration: SourceEntity {
   public var closeBracketToken: Token
   public var members: [ContractBehaviorMember]
 
-  public init(contractIdentifier: Identifier, states: [TypeState], callerBinding: Identifier?, callerProtections: [CallerProtection], closeBracketToken: Token, members: [ContractBehaviorMember]) {
+  public init(contractIdentifier: Identifier,
+              states: [TypeState],
+              callerBinding: Identifier?,
+              callerProtections: [CallerProtection],
+              closeBracketToken: Token,
+              members: [ContractBehaviorMember]) {
     self.contractIdentifier = contractIdentifier
     self.states = states
     self.callerBinding = callerBinding

--- a/Sources/AST/Declaration/ContractDeclaration.swift
+++ b/Sources/AST/Declaration/ContractDeclaration.swift
@@ -30,7 +30,8 @@ public struct ContractDeclaration: ASTNode {
   }
 
   public var stateEnumIdentifier: Identifier {
-    return Identifier(identifierToken: Token(kind: .identifier(ContractDeclaration.contractEnumPrefix+identifier.name), sourceLocation: sourceLocation))
+    return Identifier(identifierToken: Token(kind: .identifier(ContractDeclaration.contractEnumPrefix+identifier.name),
+                                             sourceLocation: sourceLocation))
   }
 
   private var stateType: Type {
@@ -41,13 +42,21 @@ public struct ContractDeclaration: ASTNode {
     let enumToken = Token(kind: .enum, sourceLocation: sourceLocation)
     let caseToken = Token(kind: .case, sourceLocation: sourceLocation)
     let intType = Type(inferredType: .basicType(.int), identifier: stateEnumIdentifier)
-    let cases: [EnumMember] = states.map{ typeState in
-      return EnumMember(caseToken: caseToken, identifier: typeState.identifier, type: stateType, hiddenValue: nil, hiddenType: intType)
+    let cases: [EnumMember] = states.map { typeState in
+      return EnumMember(caseToken: caseToken,
+                        identifier: typeState.identifier,
+                        type: stateType,
+                        hiddenValue: nil,
+                        hiddenType: intType)
     }
     return EnumDeclaration(enumToken: enumToken, identifier: stateEnumIdentifier, type: intType, cases: cases)
   }
 
-  public init(contractToken: Token, identifier: Identifier, conformances: [Conformance], states: [TypeState], members: [ContractMember]) {
+  public init(contractToken: Token,
+              identifier: Identifier,
+              conformances: [Conformance],
+              states: [TypeState],
+              members: [ContractMember]) {
     self.identifier = identifier
     self.members = members
     self.conformances = conformances

--- a/Sources/AST/Declaration/EnumDeclaration.swift
+++ b/Sources/AST/Declaration/EnumDeclaration.swift
@@ -22,7 +22,7 @@ public struct EnumDeclaration: ASTNode {
     synthesizeRawValues()
   }
 
-  mutating func synthesizeRawValues(){
+  mutating func synthesizeRawValues() {
     var lastRawValue: Expression?
     var newCases = [EnumMember]()
 
@@ -30,8 +30,7 @@ public struct EnumDeclaration: ASTNode {
       if enumCase.hiddenValue == nil, type.rawType == .basicType(.int) {
         if lastRawValue == nil {
           enumCase.hiddenValue = .literal(.init(kind: .literal(.decimal(.integer(0))), sourceLocation: .DUMMY))
-        }
-        else if case .literal(let token)? = lastRawValue,
+        } else if case .literal(let token)? = lastRawValue,
           case .literal(.decimal(.integer(let i))) = token.kind {
           enumCase.hiddenValue = .literal(.init(kind: .literal(.decimal(.integer(i + 1))), sourceLocation: .DUMMY))
         }

--- a/Sources/AST/Declaration/FunctionDeclaration.swift
+++ b/Sources/AST/Declaration/FunctionDeclaration.swift
@@ -13,12 +13,15 @@ public struct FunctionDeclaration: ASTNode {
   public var body: [Statement]
   public var closeBraceToken: Token
 
-  public var mangledIdentifier: String? = nil
+  public var mangledIdentifier: String?
 
   // Contextual information for the scope defined by the function.
-  public var scopeContext: ScopeContext? = nil
+  public var scopeContext: ScopeContext?
 
-  public init(signature: FunctionSignatureDeclaration, body: [Statement], closeBraceToken: Token, scopeContext: ScopeContext? = nil) {
+  public init(signature: FunctionSignatureDeclaration,
+              body: [Statement],
+              closeBraceToken: Token,
+              scopeContext: ScopeContext? = nil) {
     self.signature = signature
     self.body = body
     self.closeBraceToken = closeBraceToken
@@ -54,7 +57,6 @@ public struct FunctionDeclaration: ASTNode {
   public var isPublic: Bool {
     return signature.hasModifier(kind: .public)
   }
-
 
   public var identifier: Identifier {
     return signature.identifier

--- a/Sources/AST/Declaration/FunctionSignatureDeclaration.swift
+++ b/Sources/AST/Declaration/FunctionSignatureDeclaration.swift
@@ -21,14 +21,20 @@ public struct FunctionSignatureDeclaration: ASTNode, Equatable {
   public var closeBracketToken: Token
   public var resultType: Type?
 
-  public var mangledIdentifier: String? = nil
+  public var mangledIdentifier: String?
 
   /// The raw type of the function's return type.
   public var rawType: RawType {
     return resultType?.rawType ?? .basicType(.void)
   }
 
-  public init(funcToken: Token, attributes: [Attribute], modifiers: [Token], identifier: Identifier, parameters: [Parameter], closeBracketToken: Token, resultType: Type?) {
+  public init(funcToken: Token,
+              attributes: [Attribute],
+              modifiers: [Token],
+              identifier: Identifier,
+              parameters: [Parameter],
+              closeBracketToken: Token,
+              resultType: Type?) {
     self.funcToken = funcToken
     self.attributes = attributes
     self.modifiers = modifiers

--- a/Sources/AST/Declaration/Member/EnumMember.swift
+++ b/Sources/AST/Declaration/Member/EnumMember.swift
@@ -16,7 +16,7 @@ public struct EnumMember: ASTNode {
   public var hiddenValue: Expression?
   public var hiddenType: Type
 
-  public init(caseToken: Token, identifier: Identifier, type: Type, hiddenValue: Expression?, hiddenType: Type){
+  public init(caseToken: Token, identifier: Identifier, type: Type, hiddenValue: Expression?, hiddenType: Type) {
     self.caseToken = caseToken
     self.identifier = identifier
     self.hiddenValue = hiddenValue

--- a/Sources/AST/Declaration/SpecialDeclaration.swift
+++ b/Sources/AST/Declaration/SpecialDeclaration.swift
@@ -36,7 +36,10 @@ public struct SpecialDeclaration: ASTNode {
       closeBracketToken: signature.closeBracketToken,
       resultType: nil)
 
-    return FunctionDeclaration(signature: functionSignature, body: body, closeBraceToken: closeBraceToken, scopeContext: scopeContext)
+    return FunctionDeclaration(signature: functionSignature,
+                               body: body,
+                               closeBraceToken: closeBraceToken,
+                               scopeContext: scopeContext)
   }
 
   public var isInit: Bool {
@@ -50,8 +53,10 @@ public struct SpecialDeclaration: ASTNode {
     return asFunctionDeclaration.isPublic
   }
 
-
-  public init(signature: SpecialSignatureDeclaration, body: [Statement], closeBraceToken: Token, scopeContext: ScopeContext = ScopeContext()) {
+  public init(signature: SpecialSignatureDeclaration,
+              body: [Statement],
+              closeBraceToken: Token,
+              scopeContext: ScopeContext = ScopeContext()) {
     self.signature = signature
     self.body = body
     self.closeBraceToken = closeBraceToken

--- a/Sources/AST/Declaration/SpecialSignatureDeclaration.swift
+++ b/Sources/AST/Declaration/SpecialSignatureDeclaration.swift
@@ -42,7 +42,11 @@ public struct SpecialSignatureDeclaration: ASTNode {
     )
   }
 
-  public init(specialToken: Token, attributes: [Attribute], modifiers: [Token], parameters: [Parameter], closeBracketToken: Token) {
+  public init(specialToken: Token,
+              attributes: [Attribute],
+              modifiers: [Token],
+              parameters: [Parameter],
+              closeBracketToken: Token) {
     self.specialToken = specialToken
     self.attributes = attributes
     self.modifiers = modifiers

--- a/Sources/AST/Declaration/StructDeclaration.swift
+++ b/Sources/AST/Declaration/StructDeclaration.swift
@@ -75,8 +75,16 @@ public struct StructDeclaration: ASTNode {
     let dummySourceLocation = sourceLocation
     let closeBraceToken = Token(kind: .punctuation(.closeBrace), sourceLocation: dummySourceLocation)
     let closeBracketToken = Token(kind: .punctuation(.closeBracket), sourceLocation: dummySourceLocation)
-    let specialSignature = SpecialSignatureDeclaration(specialToken: Token(kind: .init, sourceLocation: dummySourceLocation), attributes: [], modifiers: [], parameters: [], closeBracketToken: closeBracketToken)
-    return SpecialDeclaration(signature: specialSignature, body: [], closeBraceToken: closeBraceToken, scopeContext: ScopeContext())
+    let specialSignature =
+      SpecialSignatureDeclaration(specialToken: Token(kind: .init, sourceLocation: dummySourceLocation),
+                                  attributes: [],
+                                  modifiers: [],
+                                  parameters: [],
+                                  closeBracketToken: closeBracketToken)
+    return SpecialDeclaration(signature: specialSignature,
+                              body: [],
+                              closeBraceToken: closeBraceToken,
+                              scopeContext: ScopeContext())
   }
 
   // MARK: - ASTNode

--- a/Sources/AST/Declaration/TopLevelDeclaration.swift
+++ b/Sources/AST/Declaration/TopLevelDeclaration.swift
@@ -22,16 +22,16 @@ public enum TopLevelDeclaration: ASTNode {
   // MARK: - ASTNode
   public var sourceLocation: SourceLocation {
     switch self {
-      case .contractDeclaration(let contractDeclaration):
-        return contractDeclaration.sourceLocation
-      case .contractBehaviorDeclaration(let behaviourDeclaration):
-        return behaviourDeclaration.sourceLocation
-      case .structDeclaration(let structDeclaration):
-        return structDeclaration.sourceLocation
-      case .enumDeclaration(let enumDeclaration):
-        return enumDeclaration.sourceLocation
-      case .traitDeclaration(let traitDeclaration):
-        return traitDeclaration.sourceLocation
+    case .contractDeclaration(let contractDeclaration):
+      return contractDeclaration.sourceLocation
+    case .contractBehaviorDeclaration(let behaviourDeclaration):
+      return behaviourDeclaration.sourceLocation
+    case .structDeclaration(let structDeclaration):
+      return structDeclaration.sourceLocation
+    case .enumDeclaration(let enumDeclaration):
+      return enumDeclaration.sourceLocation
+    case .traitDeclaration(let traitDeclaration):
+      return traitDeclaration.sourceLocation
     }
   }
 

--- a/Sources/AST/Declaration/VariableDeclaration.swift
+++ b/Sources/AST/Declaration/VariableDeclaration.swift
@@ -15,7 +15,11 @@ public struct VariableDeclaration: ASTNode {
   public var type: Type
   public var assignedExpression: Expression?
 
-  public init(modifiers: [Token], declarationToken: Token?, identifier: Identifier, type: Type, assignedExpression: Expression? = nil) {
+  public init(modifiers: [Token],
+              declarationToken: Token?,
+              identifier: Identifier,
+              type: Type,
+              assignedExpression: Expression? = nil) {
     self.modifiers = modifiers
     self.declarationToken = declarationToken
     self.identifier = identifier

--- a/Sources/AST/Environment/Environment+Checks.swift
+++ b/Sources/AST/Environment/Environment+Checks.swift
@@ -58,7 +58,8 @@ extension Environment {
   }
 
   /// Whether a struct is self referencing.
-  public func selfReferentialProperty(in type: RawTypeIdentifier, enclosingType: RawTypeIdentifier) -> PropertyInformation? {
+  public func selfReferentialProperty(in type: RawTypeIdentifier,
+                                      enclosingType: RawTypeIdentifier) -> PropertyInformation? {
     guard let enclosingMemberTypes = types[enclosingType] else { return nil }
 
     for member in enclosingMemberTypes.orderedProperties {
@@ -118,17 +119,20 @@ extension Environment {
     return conflictingDeclaration(of: event, in: declaredEvents + declaredStructs + declaredContracts + declaredEnums)
   }
 
-
   /// Attempts to find a conflicting declaration of the given function declaration
-  public func conflictingFunctionDeclaration(for function: FunctionDeclaration, in type: RawTypeIdentifier) -> Identifier? {
+  public func conflictingFunctionDeclaration(for function: FunctionDeclaration,
+                                             in type: RawTypeIdentifier) -> Identifier? {
     var contractFunctions = [Identifier]()
 
     if isContractDeclared(type) {
       // Contract functions do not support overloading.
-      contractFunctions = types[type]!.allFunctions[function.name]?.filter({ !$0.isSignature }).map { $0.declaration.identifier } ?? []
+      contractFunctions = types[type]!.allFunctions[function.name]?
+        .filter({ !$0.isSignature })
+        .map { $0.declaration.identifier } ?? []
     }
 
-    if let conflict = conflictingDeclaration(of: function.identifier, in: contractFunctions + declaredStructs + declaredContracts) {
+    if let conflict = conflictingDeclaration(of: function.identifier,
+                                             in: contractFunctions + declaredStructs + declaredContracts) {
       return conflict
     }
 
@@ -153,12 +157,14 @@ extension Environment {
   }
 
   // If the number of functions is greater than 1 (the signature of the trait) then there must be a conflict
-  public func conflictingTraitSignatures(for type: RawTypeIdentifier) -> [String : [FunctionInformation]] {
+  public func conflictingTraitSignatures(for type: RawTypeIdentifier) -> [String: [FunctionInformation]] {
     guard let typeInfo = types[type] else {
       return [:]
     }
-    return typeInfo.traitFunctions.filter{ (name, functions) in
-      functions.count > 1 && functions.contains(where: { $0.declaration.signature != functions.first!.declaration.signature})
+    return typeInfo.traitFunctions.filter { (_, functions) in
+      functions.count > 1 && functions.contains(where: {
+        $0.declaration.signature != functions.first!.declaration.signature
+      })
     }
   }
 
@@ -176,10 +182,8 @@ extension Environment {
         if conforming.isEmpty {
           notImplemented.append(contentsOf: typeInfo.allFunctions[name]!)
         }
-        for conform in conforming {
-          if conform.declaration.signature != signature.declaration.signature {
-            notImplemented.append(conform)
-          }
+        for conform in conforming where conform.declaration.signature != signature.declaration.signature {
+          notImplemented.append(conform)
         }
       }
     }

--- a/Sources/AST/Environment/Environment+MatchEvent.swift
+++ b/Sources/AST/Environment/Environment+MatchEvent.swift
@@ -16,12 +16,17 @@ extension Environment {
   }
 
   /// Associates a function call to an event call. Events are declared as properties in the contract's declaration.
-  public func matchEventCall(_ functionCall: FunctionCall, enclosingType: RawTypeIdentifier, scopeContext: ScopeContext) -> EventMatchResult {
+  public func matchEventCall(_ functionCall: FunctionCall,
+                             enclosingType: RawTypeIdentifier,
+                             scopeContext: ScopeContext) -> EventMatchResult {
     var candidates = [EventInformation]()
 
     if let events = types[enclosingType]?.allEvents[functionCall.identifier.name] {
       for candidate in events {
-        guard areArgumentsCompatible(source: functionCall.arguments, target: candidate, enclosingType: enclosingType, scopeContext: scopeContext) else {
+        guard areArgumentsCompatible(source: functionCall.arguments,
+                                     target: candidate,
+                                     enclosingType: enclosingType,
+                                     scopeContext: scopeContext) else {
             candidates.append(candidate)
             continue
         }

--- a/Sources/AST/Environment/Environment+MatchFunction.swift
+++ b/Sources/AST/Environment/Environment+MatchFunction.swift
@@ -41,7 +41,11 @@ extension Environment {
   ///   - callerProtections: The caller protections associated with the function call.
   ///   - scopeContext: Contextual information about the scope in which the function call appears.
   /// - Returns: A `FunctionCallMatchResult`, either `success` or `failure`.
-  public func matchFunctionCall(_ functionCall: FunctionCall, enclosingType: RawTypeIdentifier, typeStates: [TypeState], callerProtections: [CallerProtection], scopeContext: ScopeContext) -> FunctionCallMatchResult {
+  public func matchFunctionCall(_ functionCall: FunctionCall,
+                                enclosingType: RawTypeIdentifier,
+                                typeStates: [TypeState],
+                                callerProtections: [CallerProtection],
+                                scopeContext: ScopeContext) -> FunctionCallMatchResult {
     let match: FunctionCallMatchResult = .failure(candidates: [])
 
     let argumentTypes = functionCall.arguments.map {
@@ -49,16 +53,24 @@ extension Environment {
     }
 
     // Check if it can be a regular function.
-    let regularMatch = matchRegularFunction(functionCall: functionCall, enclosingType: enclosingType, argumentTypes: argumentTypes, typeStates: typeStates, callerProtections: callerProtections)
+    let regularMatch = matchRegularFunction(functionCall: functionCall,
+                                            enclosingType: enclosingType,
+                                            argumentTypes: argumentTypes,
+                                            typeStates: typeStates,
+                                            callerProtections: callerProtections)
 
     // Check if it can be an initializer.
-    let initaliserMatch = matchInitaliserFunction(functionCall: functionCall, argumentTypes: argumentTypes, callerProtections: callerProtections)
+    let initaliserMatch = matchInitaliserFunction(functionCall: functionCall,
+                                                  argumentTypes: argumentTypes,
+                                                  callerProtections: callerProtections)
 
     // Check if it can be a fallback function.
     let fallbackMatch = matchFallbackFunction(functionCall: functionCall, callerProtections: callerProtections)
 
     // Check if it can be a global function.
-    let globalMatch = matchGlobalFunction(functionCall: functionCall, argumentTypes: argumentTypes, callerProtections: callerProtections)
+    let globalMatch = matchGlobalFunction(functionCall: functionCall,
+                                          argumentTypes: argumentTypes,
+                                          callerProtections: callerProtections)
 
     return match.merge(with: globalMatch)
                 .merge(with: fallbackMatch)
@@ -66,7 +78,11 @@ extension Environment {
                 .merge(with: regularMatch)
   }
 
-  private func matchRegularFunction(functionCall: FunctionCall, enclosingType: RawTypeIdentifier, argumentTypes: [RawType], typeStates: [TypeState], callerProtections: [CallerProtection]) -> FunctionCallMatchResult {
+  private func matchRegularFunction(functionCall: FunctionCall,
+                                    enclosingType: RawTypeIdentifier,
+                                    argumentTypes: [RawType],
+                                    typeStates: [TypeState],
+                                    callerProtections: [CallerProtection]) -> FunctionCallMatchResult {
     var candidates = [CallableInformation]()
 
     if let functions = types[enclosingType]?.allFunctions[functionCall.identifier.name] {
@@ -80,7 +96,7 @@ extension Environment {
 
         return .matchedFunction(candidate)
       }
-      let matchedCandidates = candidates.filter{ $0.parameterTypes == argumentTypes }
+      let matchedCandidates = candidates.filter { $0.parameterTypes == argumentTypes }
       if matchedCandidates.count > 0 {
        return .matchedFunctionWithoutCaller(matchedCandidates)
       }
@@ -89,7 +105,9 @@ extension Environment {
     return .failure(candidates: candidates)
   }
 
-  private func matchInitaliserFunction(functionCall: FunctionCall, argumentTypes: [RawType], callerProtections: [CallerProtection]) -> FunctionCallMatchResult {
+  private func matchInitaliserFunction(functionCall: FunctionCall,
+                                       argumentTypes: [RawType],
+                                       callerProtections: [CallerProtection]) -> FunctionCallMatchResult {
     var candidates = [CallableInformation]()
 
     if let initializers = types[functionCall.identifier.name]?.allInitialisers {
@@ -106,7 +124,8 @@ extension Environment {
     return .failure(candidates: candidates)
   }
 
-  private func matchFallbackFunction(functionCall: FunctionCall, callerProtections: [CallerProtection]) -> FunctionCallMatchResult {
+  private func matchFallbackFunction(functionCall: FunctionCall,
+                                     callerProtections: [CallerProtection]) -> FunctionCallMatchResult {
     var candidates = [CallableInformation]()
 
     if let fallbacks = types[functionCall.identifier.name]?.fallbacks {
@@ -123,7 +142,9 @@ extension Environment {
     return .failure(candidates: candidates)
   }
 
-  private func matchGlobalFunction(functionCall: FunctionCall, argumentTypes: [RawType], callerProtections: [CallerProtection]) -> FunctionCallMatchResult {
+  private func matchGlobalFunction(functionCall: FunctionCall,
+                                   argumentTypes: [RawType],
+                                   callerProtections: [CallerProtection]) -> FunctionCallMatchResult {
     var candidates = [CallableInformation]()
 
     if let functions = types[Environment.globalFunctionStructName]?.allFunctions[functionCall.identifier.name] {

--- a/Sources/AST/Environment/Environment+Memory.swift
+++ b/Sources/AST/Environment/Environment+Memory.swift
@@ -10,15 +10,15 @@ extension Environment {
   public func size(of type: RawType) -> Int {
     switch type {
     case .basicType(.event): return 0 // Events do not use memory.
-    case .basicType(_): return 1
+    case .basicType: return 1
     case .fixedSizeArrayType(let rawType, let elementCount): return size(of: rawType) * elementCount
-    case .arrayType(_): return 1
-    case .rangeType(_): return 0 // Ranges do not use memory
-    case .dictionaryType(_, _): return 1
-    case .inoutType(_): fatalError()
+    case .arrayType: return 1
+    case .rangeType: return 0 // Ranges do not use memory
+    case .dictionaryType: return 1
+    case .inoutType: fatalError()
     case .any: return 0
     case .errorType: return 0
-    case .functionType(_): return 0
+    case .functionType: return 0
 
     case .stdlibType(let type):
       return types[type.rawValue]!.properties.reduce(0) { acc, element in
@@ -26,7 +26,7 @@ extension Environment {
       }
     case .userDefinedType(let identifier):
       if isEnumDeclared(identifier),
-        case .enumCase(let enumCase) = types[identifier]!.properties.first!.value.property{
+        case .enumCase(let enumCase) = types[identifier]!.properties.first!.value.property {
         return size(of: enumCase.hiddenType.rawType)
       }
       return types[identifier]!.properties.reduce(0) { acc, element in

--- a/Sources/AST/Environment/Environment+Type.swift
+++ b/Sources/AST/Environment/Environment+Type.swift
@@ -8,7 +8,8 @@ import Lexer
 
 extension Environment {
   /// The type of a property in the given enclosing type or in a scope if it is a local variable.
-  public func type(of property: String, enclosingType: RawTypeIdentifier, scopeContext: ScopeContext? = nil) -> RawType {
+  public func type(of property: String, enclosingType: RawTypeIdentifier,
+                   scopeContext: ScopeContext? = nil) -> RawType {
     if let type = types[enclosingType]?.properties[property]?.rawType {
       return type
     }
@@ -22,30 +23,36 @@ extension Environment {
   }
 
   /// The type return type of a function call, determined by looking up the function's declaration.
-  public func type(of functionCall: FunctionCall, enclosingType: RawTypeIdentifier, typeStates: [TypeState], callerProtections: [CallerProtection], scopeContext: ScopeContext) -> RawType? {
-    let match = matchFunctionCall(functionCall, enclosingType: enclosingType, typeStates: typeStates, callerProtections: callerProtections, scopeContext: scopeContext)
+  public func type(of functionCall: FunctionCall,
+                   enclosingType: RawTypeIdentifier,
+                   typeStates: [TypeState],
+                   callerProtections: [CallerProtection],
+                   scopeContext: ScopeContext) -> RawType? {
+    let match = matchFunctionCall(functionCall, enclosingType: enclosingType, typeStates: typeStates,
+                                  callerProtections: callerProtections, scopeContext: scopeContext)
 
     switch match {
-      case .matchedFunction(let matchingFunction): return matchingFunction.resultType
-      case .matchedFunctionWithoutCaller(let matchingFunctions):
-        guard matchingFunctions.count == 1, case .functionInformation(let functionInformation) = matchingFunctions.first! else {
-          return .errorType
-        }
-        return functionInformation.resultType
-      case .matchedInitializer(_):
-        let name = functionCall.identifier.name
-        if let stdlibType = RawType.StdlibType(rawValue: name) {
-          return .stdlibType(stdlibType)
-        }
-        return .userDefinedType(name)
-      default:
-        let eventMatch = matchEventCall(functionCall, enclosingType: enclosingType, scopeContext: scopeContext)
-        switch eventMatch {
-          case .matchedEvent(let event):
-            return .userDefinedType(event.declaration.identifier.name)
-          case .failure(_):
-            return .errorType
-        }
+    case .matchedFunction(let matchingFunction): return matchingFunction.resultType
+    case .matchedFunctionWithoutCaller(let matchingFunctions):
+      guard matchingFunctions.count == 1,
+        case .functionInformation(let functionInformation) = matchingFunctions.first! else {
+        return .errorType
+      }
+      return functionInformation.resultType
+    case .matchedInitializer:
+      let name = functionCall.identifier.name
+      if let stdlibType = RawType.StdlibType(rawValue: name) {
+        return .stdlibType(stdlibType)
+      }
+      return .userDefinedType(name)
+    default:
+      let eventMatch = matchEventCall(functionCall, enclosingType: enclosingType, scopeContext: scopeContext)
+      switch eventMatch {
+      case .matchedEvent(let event):
+        return .userDefinedType(event.declaration.identifier.name)
+      case .failure:
+        return .errorType
+      }
     }
   }
 
@@ -53,16 +60,18 @@ extension Environment {
   public func type(ofLiteralToken literalToken: Token) -> RawType {
     guard case .literal(let literal) = literalToken.kind else { fatalError() }
     switch literal {
-    case .boolean(_): return .basicType(.bool)
-    case .decimal(.integer(_)): return .basicType(.int)
-    case .string(_): return .basicType(.string)
-    case .address(_): return .basicType(.address)
+    case .boolean: return .basicType(.bool)
+    case .decimal(.integer): return .basicType(.int)
+    case .string: return .basicType(.string)
+    case .address: return .basicType(.address)
     default: fatalError()
     }
   }
 
   // The type of an array literal.
-  public func type(ofArrayLiteral arrayLiteral: ArrayLiteral, enclosingType: RawTypeIdentifier, scopeContext: ScopeContext) -> RawType {
+  public func type(ofArrayLiteral arrayLiteral: ArrayLiteral,
+                   enclosingType: RawTypeIdentifier,
+                   scopeContext: ScopeContext) -> RawType {
     var elementType: RawType?
 
     for element in arrayLiteral.elements {
@@ -82,7 +91,9 @@ extension Environment {
   }
 
   // The type of a range.
-  public func type(ofRangeExpression rangeExpression: RangeExpression, enclosingType: RawTypeIdentifier, scopeContext: ScopeContext) -> RawType {
+  public func type(ofRangeExpression rangeExpression: RangeExpression,
+                   enclosingType: RawTypeIdentifier,
+                   scopeContext: ScopeContext) -> RawType {
     let elementType = type(of: rangeExpression.initial, enclosingType: enclosingType, scopeContext: scopeContext)
     let boundType   = type(of: rangeExpression.bound, enclosingType: enclosingType, scopeContext: scopeContext)
 
@@ -94,9 +105,10 @@ extension Environment {
     return .rangeType(elementType)
   }
 
-
   // The type of a dictionary literal.
-  public func type(ofDictionaryLiteral dictionaryLiteral: DictionaryLiteral, enclosingType: RawTypeIdentifier, scopeContext: ScopeContext) -> RawType {
+  public func type(ofDictionaryLiteral dictionaryLiteral: DictionaryLiteral,
+                   enclosingType: RawTypeIdentifier,
+                   scopeContext: ScopeContext) -> RawType {
     var keyType: RawType?
     var valueType: RawType?
 
@@ -126,12 +138,20 @@ extension Environment {
     return .dictionaryType(key: keyType ?? .any, value: valueType ?? .any)
   }
 
-  public func type(of attemptExpression: AttemptExpression, enclosingType: RawTypeIdentifier, typeStates: [TypeState], callerProtections: [CallerProtection] = [], scopeContext: ScopeContext) -> RawType {
+  public func type(of attemptExpression: AttemptExpression,
+                   enclosingType: RawTypeIdentifier,
+                   typeStates: [TypeState],
+                   callerProtections: [CallerProtection] = [],
+                   scopeContext: ScopeContext) -> RawType {
     if attemptExpression.isSoft {
      return .basicType(.bool)
     }
     let functionCall = attemptExpression.functionCall
-    return type(of: functionCall, enclosingType: functionCall.identifier.enclosingType ?? enclosingType, typeStates: typeStates, callerProtections: callerProtections , scopeContext: scopeContext) ?? .errorType
+    return type(of: functionCall,
+                enclosingType: functionCall.identifier.enclosingType ?? enclosingType,
+                typeStates: typeStates,
+                callerProtections: callerProtections,
+                scopeContext: scopeContext) ?? .errorType
   }
 
   /// The type of an expression.
@@ -140,14 +160,23 @@ extension Environment {
   ///   - expression: The expression to compute the type for.
   ///   - functionDeclarationContext: Contextual information if the expression is used in a function.
   ///   - enclosingType: The enclosing type of the expression, if any.
-  ///   - callerProtections: The caller protections associated with the expression, if the expression is a function call.
+  ///   - callerProtections: The caller protections associated with the expression,
+  ///                        if the expression is a function call.
   ///   - scopeContext: Contextual information about the scope in which the expression resides.
   /// - Returns: The `RawType` of the expression.
-  public func type(of expression: Expression, enclosingType: RawTypeIdentifier, typeStates: [TypeState] = [], callerProtections: [CallerProtection] = [], scopeContext: ScopeContext) -> RawType {
+  public func type(of expression: Expression,
+                   enclosingType: RawTypeIdentifier,
+                   typeStates: [TypeState] = [],
+                   callerProtections: [CallerProtection] = [],
+                   scopeContext: ScopeContext) -> RawType {
 
     switch expression {
     case .inoutExpression(let inoutExpression):
-      return .inoutType(type(of: inoutExpression.expression, enclosingType: enclosingType, typeStates: typeStates, callerProtections: callerProtections, scopeContext: scopeContext))
+      return .inoutType(type(of: inoutExpression.expression,
+                             enclosingType: enclosingType,
+                             typeStates: typeStates,
+                             callerProtections: callerProtections,
+                             scopeContext: scopeContext))
 
     case .binaryExpression(let binaryExpression):
       if binaryExpression.opToken.isBooleanOperator {
@@ -155,20 +184,24 @@ extension Environment {
       }
 
       if binaryExpression.opToken == .dot {
-        switch type(of: binaryExpression.lhs, enclosingType: enclosingType, typeStates: typeStates, callerProtections: callerProtections, scopeContext: scopeContext) {
-        case .arrayType(_):
+        switch type(of: binaryExpression.lhs,
+                    enclosingType: enclosingType,
+                    typeStates: typeStates,
+                    callerProtections: callerProtections,
+                    scopeContext: scopeContext) {
+        case .arrayType:
           if case .identifier(let identifier) = binaryExpression.rhs, identifier.name == "size" {
             return .basicType(.int)
           } else {
             fatalError()
           }
-        case .fixedSizeArrayType(_):
+        case .fixedSizeArrayType:
           if case .identifier(let identifier) = binaryExpression.rhs, identifier.name == "size" {
             return .basicType(.int)
           } else {
             fatalError()
           }
-        case .dictionaryType(_):
+        case .dictionaryType:
           if case .identifier(let identifier) = binaryExpression.rhs, identifier.name == "size" {
             return .basicType(.int)
           } else {
@@ -179,13 +212,25 @@ extension Environment {
         }
       }
 
-      return type(of: binaryExpression.rhs, enclosingType: enclosingType, typeStates: typeStates, callerProtections: callerProtections, scopeContext: scopeContext)
+      return type(of: binaryExpression.rhs,
+                  enclosingType: enclosingType,
+                  typeStates: typeStates,
+                  callerProtections: callerProtections,
+                  scopeContext: scopeContext)
 
     case .bracketedExpression(let bracketedExpression):
-      return type(of: bracketedExpression.expression, enclosingType: enclosingType, typeStates: typeStates, callerProtections: callerProtections, scopeContext: scopeContext)
+      return type(of: bracketedExpression.expression,
+                  enclosingType: enclosingType,
+                  typeStates: typeStates,
+                  callerProtections: callerProtections,
+                  scopeContext: scopeContext)
 
     case .functionCall(let functionCall):
-      return type(of: functionCall, enclosingType: functionCall.identifier.enclosingType ?? enclosingType, typeStates: typeStates, callerProtections: callerProtections, scopeContext: scopeContext) ?? .errorType
+      return type(of: functionCall,
+                  enclosingType: functionCall.identifier.enclosingType ?? enclosingType,
+                  typeStates: typeStates,
+                  callerProtections: callerProtections,
+                  scopeContext: scopeContext) ?? .errorType
 
     case .identifier(let identifier):
       if identifier.enclosingType == nil,
@@ -195,13 +240,17 @@ extension Environment {
         }
         return type
       }
-      return type(of: identifier.name, enclosingType: identifier.enclosingType ?? enclosingType, scopeContext: scopeContext)
+      return type(of: identifier.name,
+                  enclosingType: identifier.enclosingType ?? enclosingType,
+                  scopeContext: scopeContext)
 
-    case .self(_): return .userDefinedType(enclosingType)
+    case .self: return .userDefinedType(enclosingType)
     case .variableDeclaration(let variableDeclaration):
       return variableDeclaration.type.rawType
     case .subscriptExpression(let subscriptExpression):
-      let identifierType = type(of: subscriptExpression.baseExpression, enclosingType: enclosingType, scopeContext: scopeContext)
+      let identifierType = type(of: subscriptExpression.baseExpression,
+                                enclosingType: enclosingType,
+                                scopeContext: scopeContext)
 
       switch identifierType {
       case .arrayType(let elementType): return elementType
@@ -215,10 +264,14 @@ extension Environment {
     case .range(let rangeExpression):
       return type(ofRangeExpression: rangeExpression, enclosingType: enclosingType, scopeContext: scopeContext)
     case .attemptExpression(let attemptExpression):
-       return type(of: attemptExpression, enclosingType: enclosingType, typeStates: typeStates, callerProtections: callerProtections, scopeContext: scopeContext)
+       return type(of: attemptExpression,
+                   enclosingType: enclosingType,
+                   typeStates: typeStates,
+                   callerProtections: callerProtections,
+                   scopeContext: scopeContext)
     case .dictionaryLiteral(let dictionaryLiteral):
       return type(ofDictionaryLiteral: dictionaryLiteral, enclosingType: enclosingType, scopeContext: scopeContext)
-    case .sequence(_): fatalError()
+    case .sequence: fatalError()
     case .rawAssembly(_, let resultType): return resultType!
     }
   }

--- a/Sources/AST/Environment/Environment.swift
+++ b/Sources/AST/Environment/Environment.swift
@@ -36,7 +36,8 @@ public struct Environment {
   }
 
   /// The source location of a property declaration.
-  public func propertyDeclarationSourceLocation(_ identifier: String, enclosingType: RawTypeIdentifier) -> SourceLocation? {
+  public func propertyDeclarationSourceLocation(_ identifier: String,
+                                                enclosingType: RawTypeIdentifier) -> SourceLocation? {
     return property(identifier, enclosingType)!.sourceLocation
   }
 
@@ -113,7 +114,10 @@ public struct Environment {
   }
 
   // MARK: - Compatibility
-  func areArgumentsCompatible(source: [FunctionArgument], target: EventInformation, enclosingType: String, scopeContext: ScopeContext) -> Bool {
+  func areArgumentsCompatible(source: [FunctionArgument],
+                              target: EventInformation,
+                              enclosingType: String,
+                              scopeContext: ScopeContext) -> Bool {
     let targetVariables = target.declaration.variableDeclarations
     let targetTypes = target.eventTypes
 
@@ -131,17 +135,17 @@ public struct Environment {
         identifier.name != targetVariables[targetIndex].identifier.name {
         if targetVariables[targetIndex].assignedExpression == nil {
           return false
-        }
-        else {
+        } else {
           targetIndex+=1
           continue
         }
       }
-      if targetTypes[targetIndex] == type(of: source[sourceIndex].expression, enclosingType: enclosingType, scopeContext: scopeContext){
+      if targetTypes[targetIndex] == type(of: source[sourceIndex].expression,
+                                          enclosingType: enclosingType,
+                                          scopeContext: scopeContext) {
         sourceIndex+=1
         targetIndex+=1
-      }
-      else {
+      } else {
         return false
       }
     }

--- a/Sources/AST/Environment/Information/CallableInformation.swift
+++ b/Sources/AST/Environment/Information/CallableInformation.swift
@@ -5,7 +5,6 @@
 //  Created by Harkness, Alexander on 2018-09-03
 //
 
-
 // Information about a callable unit, either a normal function or initializer/fallback function.
 public enum CallableInformation {
   case functionInformation(FunctionInformation)

--- a/Sources/AST/Environment/Information/PropertyInformation.swift
+++ b/Sources/AST/Environment/Information/PropertyInformation.swift
@@ -13,7 +13,7 @@ public struct PropertyInformation {
   public var isConstant: Bool {
     switch property {
     case .variableDeclaration(let variableDeclaration): return variableDeclaration.isConstant
-    case .enumCase(_): return true
+    case .enumCase: return true
     }
   }
 

--- a/Sources/AST/Environment/Information/TypeInformation.swift
+++ b/Sources/AST/Environment/Information/TypeInformation.swift
@@ -13,8 +13,8 @@ public struct TypeInformation {
   var events = [String: [EventInformation]]()
   var initializers = [SpecialInformation]()
   var fallbacks = [SpecialInformation]()
-  var publicInitializer: SpecialDeclaration? = nil
-  var publicFallback: SpecialDeclaration? = nil
+  var publicInitializer: SpecialDeclaration?
+  var publicFallback: SpecialDeclaration?
 
   var conformances: [TypeInformation] = []
 

--- a/Sources/AST/Expression/Expression.swift
+++ b/Sources/AST/Expression/Expression.swift
@@ -92,26 +92,26 @@ public indirect enum Expression: ASTNode {
     case .attemptExpression(let attemptExpression): return attemptExpression.sourceLocation
     case .range(let rangeExpression): return rangeExpression.sourceLocation
     case .sequence(let expressions): return expressions.first!.sourceLocation
-    case .rawAssembly(_): fatalError()
+    case .rawAssembly: fatalError()
     }
   }
   public var description: String {
     switch self {
-      case .identifier(let identifier): return identifier.description
-      case .inoutExpression(let inoutExpression): return inoutExpression.description
-      case .binaryExpression(let binaryExpression): return binaryExpression.description
-      case .functionCall(let functionCall): return functionCall.description
-      case .literal(let literal): return literal.description
-      case .arrayLiteral(let arrayLiteral): return arrayLiteral.description
-      case .dictionaryLiteral(let dictionaryLiteral): return dictionaryLiteral.description
-      case .self(let `self`): return self.description
-      case .variableDeclaration(let variableDeclaration): return variableDeclaration.description
-      case .bracketedExpression(let bracketedExpression): return bracketedExpression.description
-      case .subscriptExpression(let subscriptExpression): return subscriptExpression.description
-      case .attemptExpression(let attemptExpression): return attemptExpression.description
-      case .range(let rangeExpression): return rangeExpression.description
-      case .sequence(let expressions): return expressions.map({ $0.description }).joined(separator: "\n")
-      case .rawAssembly(_): fatalError()
+    case .identifier(let identifier): return identifier.description
+    case .inoutExpression(let inoutExpression): return inoutExpression.description
+    case .binaryExpression(let binaryExpression): return binaryExpression.description
+    case .functionCall(let functionCall): return functionCall.description
+    case .literal(let literal): return literal.description
+    case .arrayLiteral(let arrayLiteral): return arrayLiteral.description
+    case .dictionaryLiteral(let dictionaryLiteral): return dictionaryLiteral.description
+    case .self(let `self`): return self.description
+    case .variableDeclaration(let variableDeclaration): return variableDeclaration.description
+    case .bracketedExpression(let bracketedExpression): return bracketedExpression.description
+    case .subscriptExpression(let subscriptExpression): return subscriptExpression.description
+    case .attemptExpression(let attemptExpression): return attemptExpression.description
+    case .range(let rangeExpression): return rangeExpression.description
+    case .sequence(let expressions): return expressions.map({ $0.description }).joined(separator: "\n")
+    case .rawAssembly: fatalError()
     }
   }
 }

--- a/Sources/AST/Expression/FunctionCall.swift
+++ b/Sources/AST/Expression/FunctionCall.swift
@@ -14,7 +14,7 @@ public struct FunctionCall: ASTNode {
   public var closeBracketToken: Token
   public var isAttempted: Bool
 
-  public var mangledIdentifier: String? = nil
+  public var mangledIdentifier: String?
 
   public init(identifier: Identifier, arguments: [FunctionArgument], closeBracketToken: Token, isAttempted: Bool) {
     self.identifier = identifier

--- a/Sources/AST/Expression/LiteralExpression.swift
+++ b/Sources/AST/Expression/LiteralExpression.swift
@@ -30,7 +30,6 @@ public struct ArrayLiteral: ASTNode {
   }
 }
 
-
 /// A dictionary literal, such as "[1: 2, 3: 4]"
 public struct DictionaryLiteral: ASTNode {
   public var openSquareBracketToken: Token

--- a/Sources/AST/Expression/RangeExpression.swift
+++ b/Sources/AST/Expression/RangeExpression.swift
@@ -14,8 +14,8 @@ public struct RangeExpression: ASTNode {
   public var initial: Expression
   public var bound: Expression
   public var op: Token
-  
-  public init(startToken: Token, endToken: Token, initial: Expression, bound: Expression, op: Token){
+
+  public init(startToken: Token, endToken: Token, initial: Expression, bound: Expression, op: Token) {
     self.openSquareBracketToken = startToken
     self.closeSquareBracketToken = endToken
     self.initial = initial

--- a/Sources/AST/Statement/EmitStatement.swift
+++ b/Sources/AST/Statement/EmitStatement.swift
@@ -26,4 +26,3 @@ public struct EmitStatement: ASTNode {
   }
 
 }
-

--- a/Sources/AST/Statement/ForStatement.swift
+++ b/Sources/AST/Statement/ForStatement.swift
@@ -17,7 +17,7 @@ public struct ForStatement: ASTNode {
   public var body: [Statement]
 
   // Contextual information for the scope defined by the for body.
-  public var forBodyScopeContext: ScopeContext? = nil
+  public var forBodyScopeContext: ScopeContext?
 
   public var endsWithReturnStatement: Bool {
     return body.contains { statement in

--- a/Sources/AST/Statement/IfStatement.swift
+++ b/Sources/AST/Statement/IfStatement.swift
@@ -19,10 +19,10 @@ public struct IfStatement: ASTNode {
   public var elseBody: [Statement]
 
   // Contextual information for the scope defined by the if body.
-  public var ifBodyScopeContext: ScopeContext? = nil
+  public var ifBodyScopeContext: ScopeContext?
 
   // Contextual information for the scope defined by the else body.
-  public var elseBodyScopeContext: ScopeContext? = nil
+  public var elseBodyScopeContext: ScopeContext?
 
   public var endsWithReturnStatement: Bool {
     return body.contains { statement in
@@ -52,4 +52,3 @@ public struct IfStatement: ASTNode {
     return "\(ifToken) \(condition) {\(bodyText)} else {\(elseText)}"
   }
 }
-

--- a/Sources/AST/Statement/Statement.swift
+++ b/Sources/AST/Statement/Statement.swift
@@ -18,7 +18,7 @@ public indirect enum Statement: ASTNode {
 
   public var isEnding: Bool {
     switch self {
-    case .returnStatement(_), .becomeStatement(_): return true
+    case .returnStatement, .becomeStatement: return true
     default: return false
     }
   }
@@ -26,22 +26,22 @@ public indirect enum Statement: ASTNode {
   // MARK: - ASTNode
   public var sourceLocation: SourceLocation {
     switch self {
-      case .expression(let expression): return expression.sourceLocation
-      case .returnStatement(let returnStatement): return returnStatement.sourceLocation
-      case .becomeStatement(let becomeStatement): return becomeStatement.sourceLocation
-      case .ifStatement(let ifStatement): return ifStatement.sourceLocation
-      case .forStatement(let forStatement): return forStatement.sourceLocation
-      case .emitStatement(let emitStatement): return emitStatement.sourceLocation
+    case .expression(let expression): return expression.sourceLocation
+    case .returnStatement(let returnStatement): return returnStatement.sourceLocation
+    case .becomeStatement(let becomeStatement): return becomeStatement.sourceLocation
+    case .ifStatement(let ifStatement): return ifStatement.sourceLocation
+    case .forStatement(let forStatement): return forStatement.sourceLocation
+    case .emitStatement(let emitStatement): return emitStatement.sourceLocation
     }
   }
   public var description: String {
     switch self {
-      case .expression(let expression): return expression.description
-      case .returnStatement(let returnStatement): return returnStatement.description
-      case .becomeStatement(let becomeStatement): return becomeStatement.description
-      case .ifStatement(let ifStatement): return ifStatement.description
-      case .forStatement(let forStatement): return forStatement.description
-      case .emitStatement(let emitStatement): return emitStatement.description
+    case .expression(let expression): return expression.description
+    case .returnStatement(let returnStatement): return returnStatement.description
+    case .becomeStatement(let becomeStatement): return becomeStatement.description
+    case .ifStatement(let ifStatement): return ifStatement.description
+    case .forStatement(let forStatement): return forStatement.description
+    case .emitStatement(let emitStatement): return emitStatement.description
     }
   }
 }

--- a/Sources/AST/Type.swift
+++ b/Sources/AST/Type.swift
@@ -48,20 +48,21 @@ public indirect enum RawType: Equatable {
     case .inoutType(let rawType): return "$inout\(rawType.name)"
     case .any: return "Any"
     case .errorType: return "Flint$ErrorType"
-    case .functionType(let parameters, let result): return "(\(parameters.map{ $0.name }.joined(separator: ", ")) -> \(result)"
+    case .functionType(let parameters, let result):
+      return "(\(parameters.map { $0.name }.joined(separator: ", ")) -> \(result)"
     }
   }
 
   public var isBuiltInType: Bool {
     switch self {
-    case .basicType(_), .stdlibType(_), .any, .errorType: return true
+    case .basicType, .stdlibType, .any, .errorType: return true
     case .arrayType(let element): return element.isBuiltInType
     case .rangeType(let element): return element.isBuiltInType
     case .fixedSizeArrayType(let element, _): return element.isBuiltInType
     case .dictionaryType(let key, let value): return key.isBuiltInType && value.isBuiltInType
     case .inoutType(let element): return element.isBuiltInType
-    case .userDefinedType(_): return false
-    case .functionType(_): return false
+    case .userDefinedType: return false
+    case .functionType: return false
     }
   }
 
@@ -104,7 +105,6 @@ public indirect enum RawType: Equatable {
     }
   }
 }
-
 
 /// A Flint type.
 public struct Type: ASTNode {
@@ -157,7 +157,10 @@ public struct Type: ASTNode {
     sourceLocation = .spanning(type, to: closeSquareBracketToken)
   }
 
-  public init(openSquareBracketToken: Token, dictionaryWithKeyType keyType: Type, valueType: Type, closeSquareBracketToken: Token) {
+  public init(openSquareBracketToken: Token,
+              dictionaryWithKeyType keyType: Type,
+              valueType: Type,
+              closeSquareBracketToken: Token) {
     rawType = .dictionaryType(key: keyType.rawType, value: valueType.rawType)
     sourceLocation = .spanning(openSquareBracketToken, to: closeSquareBracketToken)
   }

--- a/Sources/Diagnostic/DiagnosticPool.swift
+++ b/Sources/Diagnostic/DiagnosticPool.swift
@@ -32,29 +32,27 @@ public class DiagnosticPool {
     diagnostics = []
   }
 
-  public func checkpoint(_ additions: [Diagnostic]) -> Bool? {
+  public func checkpoint(_ additions: [Diagnostic]) throws -> Bool? {
     diagnostics.append(contentsOf: additions)
 
     if hasError {
-      if shouldVerify, DiagnosticsVerifier(sourceContext).verify(producedDiagnostics: diagnostics) {
+      if shouldVerify, try DiagnosticsVerifier(sourceContext).verify(producedDiagnostics: diagnostics) {
         return false
-      }
-      else if !shouldVerify {
-        display()
+      } else if !shouldVerify {
+        try display()
         return true
-      }
-      else {
+      } else {
         return true
       }
     }
     return nil
   }
 
-  public func display() {
+  public func display() throws {
     var printableDiagnostics: [Diagnostic] = diagnostics
     if quiet {
       printableDiagnostics = diagnostics.filter({ $0.isError })
     }
-    print(DiagnosticsFormatter(diagnostics: printableDiagnostics, sourceContext: sourceContext).rendered())
+    print(try DiagnosticsFormatter(diagnostics: printableDiagnostics, sourceContext: sourceContext).rendered())
   }
 }

--- a/Sources/Diagnostic/DiagnosticsVerifier.swift
+++ b/Sources/Diagnostic/DiagnosticsVerifier.swift
@@ -13,9 +13,14 @@ import Source
 /// Verifies the diagnostics emitted by a program matches exactly what was expected.
 /// The expected diagnostics are specified inline in the source file.
 public struct DiagnosticsVerifier {
-  private let diagnosticRegex = try! NSRegularExpression(pattern: "//\\s*expected-(error|note|warning)\\s*\\s+\\{\\{(.*)\\}\\}")
-  private let diagnosticLineRegex = try! NSRegularExpression(pattern: "//\\s*expected-(error|note|warning)\\s*@(\\d+)\\s+\\{\\{(.*)\\}\\}")
-  private let diagnosticOffsetRegex = try! NSRegularExpression(pattern: "//\\s*expected-(error|note|warning)\\s*@(-|\\+)(\\d+)\\s+\\{\\{(.*)\\}\\}")
+  // swiftlint:disable force_try
+  private let diagnosticRegex =
+    try! NSRegularExpression(pattern: "//\\s*expected-(error|note|warning)\\s*\\s+\\{\\{(.*)\\}\\}")
+  private let diagnosticLineRegex =
+    try! NSRegularExpression(pattern: "//\\s*expected-(error|note|warning)\\s*@(\\d+)\\s+\\{\\{(.*)\\}\\}")
+  private let diagnosticOffsetRegex =
+    try! NSRegularExpression(pattern: "//\\s*expected-(error|note|warning)\\s*@(-|\\+)(\\d+)\\s+\\{\\{(.*)\\}\\}")
+  // swiftlint:enable force_try
 
   private let sourceContext: SourceContext
 
@@ -23,19 +28,19 @@ public struct DiagnosticsVerifier {
     self.sourceContext = sourceContext
   }
 
-  public func verify(producedDiagnostics: [Diagnostic]) -> Bool {
+  public func verify(producedDiagnostics: [Diagnostic]) throws -> Bool {
     var success = true
 
     for file in sourceContext.sourceFiles {
-      let sourceCode = sourceContext.sourceCode(in: file)
+      let sourceCode = try sourceContext.sourceCode(in: file)
       let diagnostics = producedDiagnostics.filter { $0.sourceLocation == nil || $0.sourceLocation?.file == file }
-      success = success && verify(producedDiagnostics: diagnostics, sourceFile: file, sourceCode: sourceCode)
+      success = try (success && verify(producedDiagnostics: diagnostics, sourceFile: file, sourceCode: sourceCode))
     }
 
     return success
   }
 
-  public func verify(producedDiagnostics: [Diagnostic], sourceFile: URL, sourceCode: String) -> Bool {
+  public func verify(producedDiagnostics: [Diagnostic], sourceFile: URL, sourceCode: String) throws -> Bool {
     let expectations = parseExpectations(sourceCode: sourceCode)
     var producedDiagnostics = flatten(producedDiagnostics)
     var verifyDiagnostics = [Diagnostic]()
@@ -49,22 +54,39 @@ public struct DiagnosticsVerifier {
           // 0 line locations do not exist - specifying 0 matches diagnostics with nil sourceLocation.
           equalLineLocation = expectation.line == 0
         }
-        return diagnostic.message == expectation.message && diagnostic.severity == expectation.severity && equalLineLocation
+
+        return diagnostic.message == expectation.message &&
+            diagnostic.severity == expectation.severity &&
+            equalLineLocation
       })
 
       if let index = index {
         producedDiagnostics.remove(at: index)
       } else {
-        let sourceLocation = expectation.line == 0 ? nil : SourceLocation(line: expectation.line, column: 0, length: 0, file: sourceFile)
-        verifyDiagnostics.append(Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Verify: Should have produced \(expectation.severity) \"\(expectation.message)\""))
+        let sourceLocation: SourceLocation?
+        if expectation.line == 0 {
+            sourceLocation = nil
+        } else {
+            sourceLocation = SourceLocation(line: expectation.line, column: 0, length: 0, file: sourceFile)
+        }
+
+        let diagnostic =
+            Diagnostic(severity: .error,
+                       sourceLocation: sourceLocation,
+                       message: "Verify: Should have produced \(expectation.severity) \"\(expectation.message)\"")
+        verifyDiagnostics.append(diagnostic)
       }
     }
 
     for producedDiagnostic in producedDiagnostics where producedDiagnostic.severity != .note {
-      verifyDiagnostics.append(Diagnostic(severity: .error, sourceLocation: producedDiagnostic.sourceLocation, message: "Verify: Unexpected \(producedDiagnostic.severity) \"\(producedDiagnostic.message)\""))
+        let diagnostic =
+            Diagnostic(severity: .error,
+                       sourceLocation: producedDiagnostic.sourceLocation,
+                       message: "Verify: Unexpected \(producedDiagnostic.severity) \"\(producedDiagnostic.message)\"")
+        verifyDiagnostics.append(diagnostic)
     }
 
-    let output = DiagnosticsFormatter(diagnostics: verifyDiagnostics, sourceContext: sourceContext).rendered()
+    let output = try DiagnosticsFormatter(diagnostics: verifyDiagnostics, sourceContext: sourceContext).rendered()
     if !output.isEmpty {
       print(output)
     }
@@ -90,7 +112,8 @@ public struct DiagnosticsVerifier {
   }
 
   func parseExpectation(sourceLine: String, line: Int) -> Expectation? {
-    if let match = diagnosticRegex.matches(in: sourceLine, range: NSRange(sourceLine.startIndex..., in: sourceLine)).first {
+    let range = NSRange(sourceLine.startIndex..., in: sourceLine)
+    if let match = diagnosticRegex.matches(in: sourceLine, range: range).first {
       let severityRange = Range(match.range(at: 1), in: sourceLine)!
       let severity = String(sourceLine[severityRange])
 
@@ -98,7 +121,9 @@ public struct DiagnosticsVerifier {
       let message = String(sourceLine[messageRange])
 
       return Expectation(severity: Diagnostic.Severity(rawValue: severity)!, message: message, line: line)
-    } else if let match = diagnosticLineRegex.matches(in: sourceLine, range: NSRange(sourceLine.startIndex..., in: sourceLine)).first {
+    }
+
+    if let match = diagnosticLineRegex.matches(in: sourceLine, range: range).first {
       let severityRange = Range(match.range(at: 1), in: sourceLine)!
       let severity = String(sourceLine[severityRange])
 
@@ -109,7 +134,9 @@ public struct DiagnosticsVerifier {
       let message = String(sourceLine[messageRange])
 
       return Expectation(severity: Diagnostic.Severity(rawValue: severity)!, message: message, line: line)
-    } else if let match = diagnosticOffsetRegex.matches(in: sourceLine, range: NSRange(sourceLine.startIndex..., in: sourceLine)).first {
+    }
+
+    if let match = diagnosticOffsetRegex.matches(in: sourceLine, range: range).first {
       let severityRange = Range(match.range(at: 1), in: sourceLine)!
       let severity = String(sourceLine[severityRange])
 
@@ -127,6 +154,7 @@ public struct DiagnosticsVerifier {
 
       return Expectation(severity: Diagnostic.Severity(rawValue: severity)!, message: message, line: line)
     }
+
     return nil
   }
 }

--- a/Sources/Diagnostic/SourceContext.swift
+++ b/Sources/Diagnostic/SourceContext.swift
@@ -9,11 +9,11 @@ import Foundation
 public struct SourceContext {
   var sourceFiles: [URL]
 
-  func sourceCode(in sourceFile: URL) -> String {
-    return try! String(contentsOf: sourceFile)
+  func sourceCode(in sourceFile: URL) throws -> String {
+    return try String(contentsOf: sourceFile)
   }
 
-  public init(sourceFiles: [URL]){
+  public init(sourceFiles: [URL]) {
     self.sourceFiles = sourceFiles
   }
 }

--- a/Sources/IRGen/Component/IRAssignment.swift
+++ b/Sources/IRGen/Component/IRAssignment.swift
@@ -30,12 +30,16 @@ struct IRAssignment {
 
       if functionContext.isInStructFunction {
         let enclosingName: String
-        if let enclosingParameter = functionContext.scopeContext.enclosingParameter(expression: lhs, enclosingTypeName: functionContext.enclosingTypeName) {
+        if let enclosingParameter = functionContext.scopeContext.enclosingParameter(
+            expression: lhs,
+            enclosingTypeName: functionContext.enclosingTypeName) {
           enclosingName = enclosingParameter
         } else {
           enclosingName = "flintSelf"
         }
-        return IRRuntimeFunction.store(address: lhsCode, value: rhsCode, inMemory: Mangler.isMem(for: enclosingName).mangled)
+        return IRRuntimeFunction.store(address: lhsCode,
+                                       value: rhsCode,
+                                       inMemory: Mangler.isMem(for: enclosingName).mangled)
       } else if let enclosingIdentifier = lhs.enclosingIdentifier,
         functionContext.scopeContext.containsVariableDeclaration(for: enclosingIdentifier.name) {
         return IRRuntimeFunction.store(address: lhsCode, value: rhsCode, inMemory: true)

--- a/Sources/IRGen/Component/IRIdentifier.swift
+++ b/Sources/IRGen/Component/IRIdentifier.swift
@@ -18,8 +18,10 @@ struct IRIdentifier {
   }
 
   func rendered(functionContext: FunctionContext) -> String {
-    if let _ = identifier.enclosingType {
-      return IRPropertyAccess(lhs: .self(Token(kind: .self, sourceLocation: identifier.sourceLocation)), rhs: .identifier(identifier), asLValue: asLValue).rendered(functionContext: functionContext)
+    if identifier.enclosingType != nil {
+      return IRPropertyAccess(lhs: .self(Token(kind: .self, sourceLocation: identifier.sourceLocation)),
+                              rhs: .identifier(identifier), asLValue: asLValue)
+        .rendered(functionContext: functionContext)
     }
     return identifier.name.mangled
   }

--- a/Sources/IRGen/Declaration/IRVariableDeclaration.swift
+++ b/Sources/IRGen/Declaration/IRVariableDeclaration.swift
@@ -11,7 +11,8 @@ struct IRVariableDeclaration {
   var variableDeclaration: VariableDeclaration
 
   func rendered(functionContext: FunctionContext) -> String {
-    let allocate = IRRuntimeFunction.allocateMemory(size: functionContext.environment.size(of: variableDeclaration.type.rawType) * EVM.wordSize)
+    let allocate = IRRuntimeFunction.allocateMemory(
+      size: functionContext.environment.size(of: variableDeclaration.type.rawType) * EVM.wordSize)
     return "let \(variableDeclaration.identifier.name.mangled) := \(allocate)"
   }
 }

--- a/Sources/IRGen/Expression/IRBinaryExpression.swift
+++ b/Sources/IRGen/Expression/IRBinaryExpression.swift
@@ -21,15 +21,19 @@ struct IRBinaryExpression {
       if case .functionCall(let functionCall) = binaryExpression.rhs {
         return IRFunctionCall(functionCall: functionCall).rendered(functionContext: functionContext)
       }
-      return IRPropertyAccess(lhs: binaryExpression.lhs, rhs: binaryExpression.rhs, asLValue: asLValue).rendered(functionContext: functionContext)
+      return IRPropertyAccess(lhs: binaryExpression.lhs, rhs: binaryExpression.rhs, asLValue: asLValue)
+        .rendered(functionContext: functionContext)
     }
 
-    let lhs = IRExpression(expression: binaryExpression.lhs, asLValue: asLValue).rendered(functionContext: functionContext)
-    let rhs = IRExpression(expression: binaryExpression.rhs, asLValue: asLValue).rendered(functionContext: functionContext)
+    let lhs = IRExpression(expression: binaryExpression.lhs, asLValue: asLValue)
+      .rendered(functionContext: functionContext)
+    let rhs = IRExpression(expression: binaryExpression.rhs, asLValue: asLValue)
+      .rendered(functionContext: functionContext)
 
     switch binaryExpression.opToken {
     case .equal:
-      return IRAssignment(lhs: binaryExpression.lhs, rhs: binaryExpression.rhs).rendered(functionContext: functionContext)
+      return IRAssignment(lhs: binaryExpression.lhs, rhs: binaryExpression.rhs)
+        .rendered(functionContext: functionContext)
 
     case .plus: return IRRuntimeFunction.add(a: lhs, b: rhs)
     case .overflowingPlus: return "add(\(lhs), \(rhs))"

--- a/Sources/IRGen/Expression/IRExpression.swift
+++ b/Sources/IRGen/Expression/IRExpression.swift
@@ -21,11 +21,14 @@ struct IRExpression {
   func rendered(functionContext: FunctionContext) -> String {
     switch expression {
     case .inoutExpression(let inoutExpression):
-      return IRExpression(expression: inoutExpression.expression, asLValue: true).rendered(functionContext: functionContext)
+      return IRExpression(expression: inoutExpression.expression, asLValue: true)
+        .rendered(functionContext: functionContext)
     case .binaryExpression(let binaryExpression):
-      return IRBinaryExpression(binaryExpression: binaryExpression, asLValue: asLValue).rendered(functionContext: functionContext)
+      return IRBinaryExpression(binaryExpression: binaryExpression, asLValue: asLValue)
+        .rendered(functionContext: functionContext)
     case .bracketedExpression(let bracketedExpression):
-      return IRExpression(expression: bracketedExpression.expression, asLValue: asLValue).rendered(functionContext: functionContext)
+      return IRExpression(expression: bracketedExpression.expression, asLValue: asLValue)
+        .rendered(functionContext: functionContext)
     case .attemptExpression(let attemptExpression):
       return IRAttemptExpression(attemptExpression: attemptExpression).rendered(functionContext: functionContext)
     case .functionCall(let functionCall):
@@ -49,11 +52,15 @@ struct IRExpression {
     case .self(let `self`):
       return IRSelf(selfToken: self, asLValue: asLValue).rendered(functionContext: functionContext)
     case .subscriptExpression(let subscriptExpression):
-      return IRSubscriptExpression(subscriptExpression: subscriptExpression, asLValue: asLValue).rendered(functionContext: functionContext)
+      return IRSubscriptExpression(subscriptExpression: subscriptExpression, asLValue: asLValue)
+        .rendered(functionContext: functionContext)
     case .sequence(let expressions):
-      return expressions.map { IRExpression(expression: $0, asLValue: asLValue).rendered(functionContext: functionContext) }.joined(separator: "\n")
-    case .rawAssembly(let assembly, _): return assembly
-    case .range(_): fatalError("Range shouldn't be rendered directly")
+      return expressions.map {
+            IRExpression(expression: $0, asLValue: asLValue).rendered(functionContext: functionContext)
+        }.joined(separator: "\n")
+    case .rawAssembly(let assembly, _):
+      return assembly
+    case .range: fatalError("Range shouldn't be rendered directly")
     }
   }
 }

--- a/Sources/IRGen/Expression/IRFunctionCall.swift
+++ b/Sources/IRGen/Expression/IRFunctionCall.swift
@@ -1,4 +1,3 @@
-
 //
 //  IRFunctionCall.swift
 //  IRGen
@@ -14,8 +13,12 @@ struct IRFunctionCall {
   func rendered(functionContext: FunctionContext) -> String {
     let environment = functionContext.environment
 
-    if case .matchedEvent(let eventInformation) = environment.matchEventCall(functionCall, enclosingType: functionContext.enclosingTypeName, scopeContext: functionContext.scopeContext) {
-      return IREventCall(eventCall: functionCall, eventDeclaration: eventInformation.declaration).rendered(functionContext: functionContext)
+    if case .matchedEvent(let eventInformation) =
+      environment.matchEventCall(functionCall,
+                                 enclosingType: functionContext.enclosingTypeName,
+                                 scopeContext: functionContext.scopeContext) {
+      return IREventCall(eventCall: functionCall, eventDeclaration: eventInformation.declaration)
+        .rendered(functionContext: functionContext)
     }
 
     let args: String = functionCall.arguments.map({ argument in

--- a/Sources/IRGen/Function/IRContractInitializer.swift
+++ b/Sources/IRGen/Function/IRContractInitializer.swift
@@ -23,15 +23,25 @@ struct IRContractInitializer {
   var isContractFunction = false
 
   var parameterNames: [String] {
-    let fc = FunctionContext(environment: environment, scopeContext: scopeContext, enclosingTypeName: typeIdentifier.name, isInStructFunction: !isContractFunction)
-    return initializerDeclaration.explicitParameters.map { IRIdentifier(identifier: $0.identifier).rendered(functionContext: fc) }
+    let fc = FunctionContext(environment: environment,
+                             scopeContext: scopeContext,
+                             enclosingTypeName: typeIdentifier.name,
+                             isInStructFunction: !isContractFunction)
+    return initializerDeclaration.explicitParameters.map {
+        IRIdentifier(identifier: $0.identifier).rendered(functionContext: fc)
+    }
   }
 
   /// The function's parameters and caller binding, as variable declarations in a `ScopeContext`.
   var scopeContext: ScopeContext {
     var localVariables = [VariableDeclaration]()
     if let callerBinding = callerBinding {
-      localVariables.append(VariableDeclaration(modifiers: [], declarationToken: nil, identifier: callerBinding, type: Type(inferredType: .basicType(.address), identifier: callerBinding)))
+      let variableDeclaration = VariableDeclaration(modifiers: [],
+                                                    declarationToken: nil,
+                                                    identifier: callerBinding,
+                                                    type: Type(inferredType: .basicType(.address),
+                                                               identifier: callerBinding))
+      localVariables.append(variableDeclaration)
     }
     return ScopeContext(parameters: initializerDeclaration.signature.parameters, localVariables: localVariables)
   }
@@ -52,7 +62,12 @@ struct IRContractInitializer {
       """
     }.joined(separator: "\n")
 
-    let body = IRFunctionBody(functionDeclaration: initializerDeclaration.asFunctionDeclaration, typeIdentifier: typeIdentifier, callerBinding: callerBinding, callerProtections: callerProtections, environment: environment, isContractFunction: isContractFunction).rendered()
+    let body = IRFunctionBody(functionDeclaration: initializerDeclaration.asFunctionDeclaration,
+                              typeIdentifier: typeIdentifier,
+                              callerBinding: callerBinding,
+                              callerProtections: callerProtections,
+                              environment: environment,
+                              isContractFunction: isContractFunction).rendered()
 
     return """
     init()

--- a/Sources/IRGen/Function/IRFallback.swift
+++ b/Sources/IRGen/Function/IRFallback.swift
@@ -15,7 +15,10 @@ struct IRContractFallback {
   var environment: Environment
 
   var functionContext: FunctionContext {
-    return FunctionContext(environment: environment, scopeContext: ScopeContext(), enclosingTypeName: typeIdentifier.name, isInStructFunction: false)
+    return FunctionContext(environment: environment,
+                           scopeContext: ScopeContext(),
+                           enclosingTypeName: typeIdentifier.name,
+                           isInStructFunction: false)
   }
 
   var parameterNames: [String] {
@@ -25,6 +28,11 @@ struct IRContractFallback {
   }
 
   func rendered() -> String {
-    return IRFunctionBody(functionDeclaration: fallbackDeclaration.asFunctionDeclaration, typeIdentifier: typeIdentifier, callerBinding: nil, callerProtections: [], environment: environment, isContractFunction: true).rendered()
+    return IRFunctionBody(functionDeclaration: fallbackDeclaration.asFunctionDeclaration,
+                          typeIdentifier: typeIdentifier,
+                          callerBinding: nil,
+                          callerProtections: [],
+                          environment: environment,
+                          isContractFunction: true).rendered()
   }
 }

--- a/Sources/IRGen/Function/IRFunction.swift
+++ b/Sources/IRGen/Function/IRFunction.swift
@@ -27,7 +27,12 @@ struct IRFunction {
     return callerProtections.contains(where: { $0.isAny })
   }
 
-  init(functionDeclaration: FunctionDeclaration, typeIdentifier: Identifier, typeStates: [TypeState] = [], callerBinding: Identifier? = nil, callerProtections: [CallerProtection] = [], environment: Environment) {
+  init(functionDeclaration: FunctionDeclaration,
+       typeIdentifier: Identifier,
+       typeStates: [TypeState] = [],
+       callerBinding: Identifier? = nil,
+       callerProtections: [CallerProtection] = [],
+       environment: Environment) {
     self.functionDeclaration = functionDeclaration
     self.typeIdentifier = typeIdentifier
     self.typeStates = typeStates
@@ -42,8 +47,13 @@ struct IRFunction {
   }
 
   var parameterNames: [String] {
-    let fc = FunctionContext(environment: environment, scopeContext: scopeContext, enclosingTypeName: typeIdentifier.name, isInStructFunction: !isContractFunction)
-    return functionDeclaration.explicitParameters.map {IRIdentifier(identifier: $0.identifier).rendered(functionContext: fc)}
+    let fc = FunctionContext(environment: environment,
+                             scopeContext: scopeContext,
+                             enclosingTypeName: typeIdentifier.name,
+                             isInStructFunction: !isContractFunction)
+    return functionDeclaration.explicitParameters.map {
+        IRIdentifier(identifier: $0.identifier).rendered(functionContext: fc)
+    }
   }
 
   /// The function's parameters and caller caller binding, as variable declarations in a `ScopeContext`.
@@ -60,7 +70,12 @@ struct IRFunction {
   }
 
   func rendered() -> String {
-    let body = IRFunctionBody(functionDeclaration: functionDeclaration, typeIdentifier: typeIdentifier, callerBinding: callerBinding, callerProtections: callerProtections, environment: environment, isContractFunction: isContractFunction).rendered()
+    let body = IRFunctionBody(functionDeclaration: functionDeclaration,
+                              typeIdentifier: typeIdentifier,
+                              callerBinding: callerBinding,
+                              callerProtections: callerProtections,
+                              environment: environment,
+                              isContractFunction: isContractFunction).rendered()
 
     return """
     function \(signature()) {
@@ -100,7 +115,12 @@ struct IRFunctionBody {
     return functionDeclaration.scopeContext!
   }
 
-  init(functionDeclaration: FunctionDeclaration, typeIdentifier: Identifier, callerBinding: Identifier?, callerProtections: [CallerProtection], environment: Environment, isContractFunction: Bool) {
+  init(functionDeclaration: FunctionDeclaration,
+       typeIdentifier: Identifier,
+       callerBinding: Identifier?,
+       callerProtections: [CallerProtection],
+       environment: Environment,
+       isContractFunction: Bool) {
      self.functionDeclaration = functionDeclaration
      self.typeIdentifier = typeIdentifier
      self.callerProtections = callerProtections
@@ -110,7 +130,10 @@ struct IRFunctionBody {
    }
 
   func rendered() -> String {
-    let functionContext: FunctionContext = FunctionContext(environment: environment, scopeContext: scopeContext, enclosingTypeName: typeIdentifier.name, isInStructFunction: !isContractFunction)
+    let functionContext: FunctionContext = FunctionContext(environment: environment,
+                                                           scopeContext: scopeContext,
+                                                           enclosingTypeName: typeIdentifier.name,
+                                                           isInStructFunction: !isContractFunction)
 
     // Assign a caller capaiblity binding to a local variable.
     let callerBindingDeclaration: String
@@ -125,7 +148,9 @@ struct IRFunctionBody {
     return "\(callerBindingDeclaration)\(body)"
   }
 
-  func renderBody<S : RandomAccessCollection & RangeReplaceableCollection>(_ statements: S, functionContext: FunctionContext) -> String where S.Element == AST.Statement, S.Index == Int {
+  func renderBody<S: RandomAccessCollection & RangeReplaceableCollection>(_ statements: S,
+                                                                          functionContext: FunctionContext) -> String
+    where S.Element == AST.Statement, S.Index == Int {
     guard !statements.isEmpty else { return "" }
     var statements = statements
     let first = statements.removeFirst()

--- a/Sources/IRGen/IRCanonicalType.swift
+++ b/Sources/IRGen/IRCanonicalType.swift
@@ -22,7 +22,7 @@ enum CanonicalType: String {
       case .string: self = .bytes32
       default: return nil
       }
-    case .userDefinedType(_): self = .uint256
+    case .userDefinedType: self = .uint256
     case .inoutType(let rawType):
       guard let type = CanonicalType(from: rawType) else { return nil }
       self = type

--- a/Sources/IRGen/IRCodeGenerator.swift
+++ b/Sources/IRGen/IRCodeGenerator.swift
@@ -41,7 +41,10 @@ public struct IRCodeGenerator {
         return structDeclaration
       }
 
-      let contract = IRContract(contractDeclaration: contractDeclaration, contractBehaviorDeclarations: behaviorDeclarations, structDeclarations: structDeclarations, environment: environment)
+      let contract = IRContract(contractDeclaration: contractDeclaration,
+                                contractBehaviorDeclarations: behaviorDeclarations,
+                                structDeclarations: structDeclarations,
+                                environment: environment)
       contracts.append(contract)
       interfaces.append(IRInterface(contract: contract, environment: environment))
     }

--- a/Sources/IRGen/IRInterface.swift
+++ b/Sources/IRGen/IRInterface.swift
@@ -18,10 +18,10 @@ struct IRInterface {
         switch member {
         case .functionDeclaration(let functionDeclaration):
           return render(functionDeclaration)
-        case .specialDeclaration(_):
+        case .specialDeclaration:
           return ""
           // Rendering initializers/fallback is not supported yet.
-        case .functionSignatureDeclaration(_), .specialSignatureDeclaration(_):
+        case .functionSignatureDeclaration, .specialSignatureDeclaration:
           fatalError("No signatures in contract body")
         }
       }
@@ -51,7 +51,9 @@ struct IRInterface {
 
     var attribute = ""
 
-    if !functionDeclaration.isMutating, !functionDeclaration.containsEventCall(environment: environment, contractIdentifier: contract.contractDeclaration.identifier) {
+    if !functionDeclaration.isMutating,
+        !functionDeclaration.containsEventCall(environment: environment,
+                                               contractIdentifier: contract.contractDeclaration.identifier) {
       attribute = "view "
     }
 
@@ -70,7 +72,9 @@ struct IRInterface {
   }
 
   func render(_ functionParameter: Parameter) -> String {
-    return "\(CanonicalType(from: functionParameter.type.rawType)!.rawValue) \(functionParameter.identifier.name.mangled)"
+    let canonicalType = CanonicalType(from: functionParameter.type.rawType)!.rawValue
+    let mangledName = functionParameter.identifier.name.mangled
+    return "\(canonicalType) \(mangledName)"
   }
 }
 

--- a/Sources/IRGen/IRStruct.swift
+++ b/Sources/IRGen/IRStruct.swift
@@ -19,7 +19,9 @@ public struct IRStruct {
   func rendered() -> String {
     // At this point, the initializers and conforming functions have been converted to functions.
     let functionsCode = structDeclaration.functionDeclarations.compactMap { functionDeclaration in
-      return IRFunction(functionDeclaration: functionDeclaration, typeIdentifier: structDeclaration.identifier, environment: environment).rendered()
+      return IRFunction(functionDeclaration: functionDeclaration,
+                        typeIdentifier: structDeclaration.identifier,
+                        environment: environment).rendered()
     }.joined(separator: "\n\n")
 
     return functionsCode

--- a/Sources/IRGen/Preprocessor/IRPreprocessor+Expressions.swift
+++ b/Sources/IRGen/Preprocessor/IRPreprocessor+Expressions.swift
@@ -20,13 +20,15 @@ extension IRPreprocessor {
         case .identifier(let lhsId) = binaryExpression.lhs,
         case .identifier(let rhsId) = binaryExpression.rhs,
         environment.isEnumDeclared(lhsId.name),
-        let matchingProperty = environment.propertyDeclarations(in: lhsId.name).filter({ $0.identifier.identifierToken.kind == rhsId.identifierToken.kind }).first,
+        let matchingProperty = environment.propertyDeclarations(in: lhsId.name)
+          .filter({ $0.identifier.identifierToken.kind == rhsId.identifierToken.kind }).first,
         matchingProperty.type!.rawType != .errorType {
         expression = matchingProperty.value!
       } else if case .equal = binaryExpression.opToken,
         case .functionCall(var functionCall) = binaryExpression.rhs {
 
-        let ampersandToken: Token = Token(kind: .punctuation(.ampersand), sourceLocation: binaryExpression.lhs.sourceLocation)
+        let ampersandToken: Token = Token(kind: .punctuation(.ampersand),
+                                          sourceLocation: binaryExpression.lhs.sourceLocation)
 
         if environment.isInitializerCall(functionCall) {
           // If we're initializing a struct, pass the lhs expression as the first parameter of the initializer call.
@@ -37,7 +39,9 @@ extension IRPreprocessor {
 
           if case .variableDeclaration(let variableDeclaration) = binaryExpression.lhs,
             variableDeclaration.type.rawType.isDynamicType {
-            functionCall.arguments[0] = FunctionArgument(.inoutExpression(InoutExpression(ampersandToken: ampersandToken, expression: .identifier(variableDeclaration.identifier))))
+            functionCall.arguments[0] = FunctionArgument(
+              .inoutExpression(InoutExpression(ampersandToken: ampersandToken,
+                                               expression: .identifier(variableDeclaration.identifier))))
             expression = .sequence([.variableDeclaration(variableDeclaration), .functionCall(functionCall)])
           }
         }
@@ -47,7 +51,8 @@ extension IRPreprocessor {
     return ASTPassResult(element: expression, diagnostics: [], passContext: passContext)
   }
 
-  public func process(binaryExpression: BinaryExpression, passContext: ASTPassContext) -> ASTPassResult<BinaryExpression> {
+  public func process(binaryExpression: BinaryExpression,
+                      passContext: ASTPassContext) -> ASTPassResult<BinaryExpression> {
     var passContext = passContext
     var binaryExpression = binaryExpression
 
@@ -55,7 +60,9 @@ extension IRPreprocessor {
       let sourceLocation = binaryExpression.op.sourceLocation
       let token = Token(kind: .punctuation(op), sourceLocation: sourceLocation)
       binaryExpression.op = Token(kind: .punctuation(.equal), sourceLocation: sourceLocation)
-      binaryExpression.rhs = .binaryExpression(BinaryExpression(lhs: binaryExpression.lhs, op: token, rhs: binaryExpression.rhs))
+      binaryExpression.rhs = .binaryExpression(BinaryExpression(lhs: binaryExpression.lhs,
+                                                                op: token,
+                                                                rhs: binaryExpression.rhs))
     } else if case .dot = binaryExpression.opToken {
       let trail = passContext.functionCallReceiverTrail ?? []
       passContext.functionCallReceiverTrail = trail + [binaryExpression.lhs]
@@ -63,7 +70,8 @@ extension IRPreprocessor {
 
     // Convert <= and >= expressions.
     if [.lessThanOrEqual, .greaterThanOrEqual].contains(binaryExpression.opToken) {
-      let strictOperator: Token.Kind.Punctuation = binaryExpression.opToken == .lessThanOrEqual ? .openAngledBracket : .closeAngledBracket
+      let strictOperator: Token.Kind.Punctuation =
+        binaryExpression.opToken == .lessThanOrEqual ? .openAngledBracket : .closeAngledBracket
 
       var lhsExpression = binaryExpression
       lhsExpression.op = Token(kind: .punctuation(strictOperator), sourceLocation: lhsExpression.op.sourceLocation)
@@ -81,7 +89,8 @@ extension IRPreprocessor {
     return ASTPassResult(element: binaryExpression, diagnostics: [], passContext: passContext)
   }
 
-  func constructExpression<Expressions: Sequence & RandomAccessCollection>(from expressions: Expressions) -> Expression where Expressions.Element == Expression {
+  func constructExpression<Expressions: Sequence & RandomAccessCollection>(from expressions: Expressions) -> Expression
+    where Expressions.Element == Expression {
     guard expressions.count > 1 else { return expressions.first! }
     let head = expressions.first!
     let tail = expressions.dropFirst()
@@ -127,7 +136,10 @@ extension IRPreprocessor {
       if isGlobalFunctionCall {
         declarationEnclosingType = Environment.globalFunctionStructName
       } else {
-        declarationEnclosingType = passContext.environment!.type(of: receiverTrail.last!, enclosingType: enclosingType, callerProtections: callerProtections, scopeContext: scopeContext).name
+        declarationEnclosingType = passContext.environment!.type(of: receiverTrail.last!,
+                                                                 enclosingType: enclosingType,
+                                                                 callerProtections: callerProtections,
+                                                                 scopeContext: scopeContext).name
       }
 
       // Set the mangled identifier for the function.
@@ -137,13 +149,19 @@ extension IRPreprocessor {
       if passContext.environment!.isStructDeclared(declarationEnclosingType) {
         if !isGlobalFunctionCall {
           let receiver = constructExpression(from: receiverTrail)
-          let inoutExpression = InoutExpression(ampersandToken: Token(kind: .punctuation(.ampersand), sourceLocation: receiver.sourceLocation), expression: receiver)
+          let inoutExpression = InoutExpression(ampersandToken: Token(kind: .punctuation(.ampersand),
+                                                                      sourceLocation: receiver.sourceLocation),
+                                                expression: receiver)
           functionCall.arguments.insert(FunctionArgument(.inoutExpression(inoutExpression)), at: 0)
         }
       }
     }
 
-    guard case .failure(let candidates) = environment.matchEventCall(functionCall, enclosingType: enclosingType, scopeContext: passContext.scopeContext ?? ScopeContext()), candidates.isEmpty else {
+    guard case .failure(let candidates) =
+      environment.matchEventCall(functionCall,
+                                 enclosingType: enclosingType,
+                                 scopeContext: passContext.scopeContext ?? ScopeContext()),
+      candidates.isEmpty else {
       return ASTPassResult(element: functionCall, diagnostics: [], passContext: passContext)
     }
     // For each non-implicit dynamic type, add an isMem parameter.
@@ -151,23 +169,35 @@ extension IRPreprocessor {
     for (index, argument) in functionCall.arguments.enumerated() {
       let isMem: Expression
 
-      if let parameterName = scopeContext.enclosingParameter(expression: argument.expression, enclosingTypeName: enclosingType),
+      if let parameterName = scopeContext.enclosingParameter(expression: argument.expression,
+                                                             enclosingTypeName: enclosingType),
         scopeContext.isParameterImplicit(parameterName) {
         isMem = .literal(Token(kind: .literal(.boolean(.true)), sourceLocation: argument.sourceLocation))
       } else {
-        let type = passContext.environment!.type(of: argument.expression, enclosingType: enclosingType, typeStates: typeStates, callerProtections: callerProtections, scopeContext: scopeContext)
+        let type = passContext.environment!.type(of: argument.expression,
+                                                 enclosingType: enclosingType,
+                                                 typeStates: typeStates,
+                                                 callerProtections: callerProtections,
+                                                 scopeContext: scopeContext)
         guard type != .errorType else { fatalError() }
         guard type.isDynamicType else { continue }
 
-        if let enclosingIdentifier = argument.expression.enclosingIdentifier, scopeContext.containsVariableDeclaration(for: enclosingIdentifier.name) {
+        if let enclosingIdentifier = argument.expression.enclosingIdentifier,
+          scopeContext.containsVariableDeclaration(for: enclosingIdentifier.name) {
           // If the argument is declared locally, it's stored in memory.
           isMem = .literal(Token(kind: .literal(.boolean(.true)), sourceLocation: argument.sourceLocation))
-        } else if let enclosingIdentifier = argument.expression.enclosingIdentifier, scopeContext.containsParameterDeclaration(for: enclosingIdentifier.name) {
+        } else if let enclosingIdentifier = argument.expression.enclosingIdentifier,
+          scopeContext.containsParameterDeclaration(for: enclosingIdentifier.name) {
           // If the argument is a parameter to the enclosing function, use its isMem parameter.
-          isMem = .identifier(Identifier(identifierToken: Token(kind: .identifier(Mangler.isMem(for: enclosingIdentifier.name)), sourceLocation: argument.sourceLocation)))
-        } else if case .inoutExpression(let inoutExpression) = argument.expression, case .self(_) = inoutExpression.expression {
+          isMem = .identifier(
+            Identifier(identifierToken: Token(kind: .identifier(Mangler.isMem(for: enclosingIdentifier.name)),
+                                              sourceLocation: argument.sourceLocation)))
+        } else if case .inoutExpression(let inoutExpression) = argument.expression,
+          case .self(_) = inoutExpression.expression {
           // If the argument is self, use flintSelf
-          isMem = .identifier(Identifier(identifierToken: Token(kind: .identifier(Mangler.isMem(for: "flintSelf")), sourceLocation: argument.sourceLocation)))
+          isMem = .identifier(
+            Identifier(identifierToken: Token(kind: .identifier(Mangler.isMem(for: "flintSelf")),
+                                              sourceLocation: argument.sourceLocation)))
         } else {
           // Otherwise, the argument refers to a property, which is not in memory.
           isMem = .literal(Token(kind: .literal(.boolean(.false)), sourceLocation: argument.sourceLocation))
@@ -193,19 +223,28 @@ extension IRPreprocessor {
     let enclosingType: String = functionCall.identifier.enclosingType ?? passContext.enclosingTypeIdentifier!.name
 
     // Don't mangle event calls
-    if case .matchedEvent(_) = environment.matchEventCall(functionCall, enclosingType: enclosingType, scopeContext: passContext.scopeContext ?? ScopeContext()) {
+    if case .matchedEvent(_) =
+      environment.matchEventCall(functionCall,
+                                 enclosingType: enclosingType,
+                                 scopeContext: passContext.scopeContext ?? ScopeContext()) {
       return functionCall.identifier.name
     }
 
     let typeStates = passContext.contractBehaviorDeclarationContext?.typeStates ?? []
     let callerProtections = passContext.contractBehaviorDeclarationContext?.callerProtections ?? []
-    let matchResult = environment.matchFunctionCall(functionCall, enclosingType: enclosingType, typeStates: typeStates, callerProtections: callerProtections, scopeContext: passContext.scopeContext!)
+    let matchResult = environment.matchFunctionCall(functionCall,
+                                                    enclosingType: enclosingType,
+                                                    typeStates: typeStates,
+                                                    callerProtections: callerProtections,
+                                                    scopeContext: passContext.scopeContext!)
 
     switch matchResult {
     case .matchedFunction(let functionInformation):
       let declaration = functionInformation.declaration
       let parameterTypes = declaration.signature.parameters.map { $0.type.rawType }
-      return Mangler.mangleFunctionName(declaration.identifier.name, parameterTypes: parameterTypes, enclosingType: enclosingType)
+      return Mangler.mangleFunctionName(declaration.identifier.name,
+                                        parameterTypes: parameterTypes,
+                                        enclosingType: enclosingType)
     case .matchedFunctionWithoutCaller(let candidates):
       guard candidates.count == 1 else {
         fatalError("Unable to find unique declaration of \(functionCall)")
@@ -215,17 +254,21 @@ extension IRPreprocessor {
       }
       let declaration = candidate.declaration
       let parameterTypes = declaration.signature.parameters.map { $0.type.rawType }
-      return Mangler.mangleFunctionName(declaration.identifier.name, parameterTypes: parameterTypes, enclosingType: enclosingType)
+      return Mangler.mangleFunctionName(declaration.identifier.name,
+                                        parameterTypes: parameterTypes,
+                                        enclosingType: enclosingType)
     case .matchedInitializer(let initializerInformation):
       let declaration = initializerInformation.declaration
       let parameterTypes = declaration.signature.parameters.map { $0.type.rawType }
       return Mangler.mangleInitializerName(functionCall.identifier.name, parameterTypes: parameterTypes)
-    case .matchedFallback(_):
+    case .matchedFallback:
       return Mangler.mangleInitializerName(functionCall.identifier.name, parameterTypes: [])
     case .matchedGlobalFunction(let functionInformation):
       let parameterTypes = functionInformation.declaration.signature.parameters.map { $0.type.rawType }
-      return Mangler.mangleFunctionName(functionCall.identifier.name, parameterTypes: parameterTypes, enclosingType: Environment.globalFunctionStructName)
-    case .failure(_):
+      return Mangler.mangleFunctionName(functionCall.identifier.name,
+                                        parameterTypes: parameterTypes,
+                                        enclosingType: Environment.globalFunctionStructName)
+    case .failure:
       return nil
     }
   }
@@ -237,7 +280,11 @@ extension IRPreprocessor {
     let scopeContext = passContext.scopeContext!
     let environment = passContext.environment!
 
-    let match = environment.matchFunctionCall(functionCall, enclosingType: enclosingType, typeStates: typeStates, callerProtections: callerProtections, scopeContext: scopeContext)
+    let match = environment.matchFunctionCall(functionCall,
+                                              enclosingType: enclosingType,
+                                              typeStates: typeStates,
+                                              callerProtections: callerProtections,
+                                              scopeContext: scopeContext)
 
     // Mangle global function
     if case .matchedGlobalFunction(_) = match {

--- a/Sources/IRGen/Preprocessor/IRPreprocessor.swift
+++ b/Sources/IRGen/Preprocessor/IRPreprocessor.swift
@@ -40,31 +40,38 @@ public struct IRPreprocessor: ASTPass {
       var identifier = declaration.identifier
       identifier.enclosingType = enclosingType
 
-      return .expression(.binaryExpression(BinaryExpression(lhs: .identifier(identifier), op: Token(kind: .punctuation(.equal), sourceLocation: identifier.sourceLocation), rhs: assignedExpression)))
+      return .expression(
+        .binaryExpression(
+          BinaryExpression(lhs: .identifier(identifier),
+                           op: Token(kind: .punctuation(.equal), sourceLocation: identifier.sourceLocation),
+                           rhs: assignedExpression)))
     }
   }
 
   // MARK: Declaration
-  public func process(structDeclaration: StructDeclaration, passContext: ASTPassContext) -> ASTPassResult<StructDeclaration> {
+  public func process(structDeclaration: StructDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<StructDeclaration> {
     let environment = passContext.environment!
     var structDeclaration = structDeclaration
 
-    let conformingFunctions = environment.conformingFunctions(in: structDeclaration.identifier.name).compactMap { functionInformation -> StructMember in
-      var functionDeclaration = functionInformation.declaration
-      functionDeclaration.scopeContext = ScopeContext()
+    let conformingFunctions = environment.conformingFunctions(in: structDeclaration.identifier.name)
+      .compactMap { functionInformation -> StructMember in
+        var functionDeclaration = functionInformation.declaration
+        functionDeclaration.scopeContext = ScopeContext()
 
-      return .functionDeclaration(functionDeclaration)
-    }
+        return .functionDeclaration(functionDeclaration)
+      }
 
     structDeclaration.members += conformingFunctions
 
     return ASTPassResult(element: structDeclaration, diagnostics: [], passContext: passContext)
   }
 
-  public func process(variableDeclaration: VariableDeclaration, passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration> {
+  public func process(variableDeclaration: VariableDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration> {
     var passContext = passContext
 
-    if let _ = passContext.functionDeclarationContext {
+    if passContext.functionDeclarationContext != nil {
       // We're in a function. Record the local variable declaration.
       passContext.scopeContext?.localVariables += [variableDeclaration]
     }
@@ -72,39 +79,64 @@ public struct IRPreprocessor: ASTPass {
     return ASTPassResult(element: variableDeclaration, diagnostics: [], passContext: passContext)
   }
 
-  public func process(functionDeclaration: FunctionDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
+  public func process(functionDeclaration: FunctionDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
     var functionDeclaration = functionDeclaration
 
     // Mangle the function name in the declaration.
     let parameters = functionDeclaration.signature.parameters.map { $0.type.rawType }
-    let name = Mangler.mangleFunctionName(functionDeclaration.identifier.name, parameterTypes: parameters, enclosingType: passContext.enclosingTypeIdentifier!.name)
+    let name = Mangler.mangleFunctionName(functionDeclaration.identifier.name,
+                                          parameterTypes: parameters,
+                                          enclosingType: passContext.enclosingTypeIdentifier!.name)
     functionDeclaration.mangledIdentifier = name
 
     // Bind the implicit Wei value of the transaction to a variable.
-    if functionDeclaration.isPayable, let payableParameterIdentifier = functionDeclaration.firstPayableValueParameter?.identifier {
-      let weiType = Identifier(identifierToken: Token(kind: .identifier("Wei"), sourceLocation: payableParameterIdentifier.sourceLocation))
-      let variableDeclaration = VariableDeclaration(modifiers: [], declarationToken: nil, identifier: payableParameterIdentifier, type: Type(identifier: weiType))
-      let closeBracketToken = Token(kind: .punctuation(.closeBracket), sourceLocation: payableParameterIdentifier.sourceLocation)
-      let wei = FunctionCall(identifier: weiType, arguments: [FunctionArgument(identifier: nil, expression: .rawAssembly(IRRuntimeFunction.callvalue(), resultType: .basicType(.int)))], closeBracketToken: closeBracketToken, isAttempted: false)
+    if functionDeclaration.isPayable,
+      let payableParameterIdentifier = functionDeclaration.firstPayableValueParameter?.identifier {
+      let weiType = Identifier(identifierToken: Token(kind: .identifier("Wei"),
+                                                      sourceLocation: payableParameterIdentifier.sourceLocation))
+      let variableDeclaration = VariableDeclaration(modifiers: [],
+                                                    declarationToken: nil,
+                                                    identifier: payableParameterIdentifier,
+                                                    type: Type(identifier: weiType))
+      let closeBracketToken = Token(kind: .punctuation(.closeBracket),
+                                    sourceLocation: payableParameterIdentifier.sourceLocation)
+      let wei = FunctionCall(identifier: weiType,
+                             arguments: [
+                               FunctionArgument(identifier: nil,
+                                                expression: .rawAssembly(IRRuntimeFunction.callvalue(),
+                                                                         resultType: .basicType(.int)))
+                             ],
+                             closeBracketToken: closeBracketToken,
+                             isAttempted: false)
       let equal = Token(kind: .punctuation(.equal), sourceLocation: payableParameterIdentifier.sourceLocation)
-      let assignment: Expression = .binaryExpression(BinaryExpression(lhs: .variableDeclaration(variableDeclaration), op: equal, rhs: .functionCall(wei)))
+      let assignment: Expression = .binaryExpression(
+        BinaryExpression(lhs: .variableDeclaration(variableDeclaration),
+                         op: equal,
+                         rhs: .functionCall(wei)))
       functionDeclaration.body.insert(.expression(assignment), at: 0)
     }
 
     if let structDeclarationContext = passContext.structDeclarationContext {
       if Environment.globalFunctionStructName != passContext.enclosingTypeIdentifier?.name {
         // For struct functions, add `flintSelf` to the beginning of the parameters list.
-        let parameter = constructParameter(name: "flintSelf", type: .inoutType(.userDefinedType(structDeclarationContext.structIdentifier.name)), sourceLocation: functionDeclaration.sourceLocation)
+        let parameter = constructParameter(
+          name: "flintSelf",
+          type: .inoutType(.userDefinedType(structDeclarationContext.structIdentifier.name)),
+          sourceLocation: functionDeclaration.sourceLocation)
         functionDeclaration.signature.parameters.insert(parameter, at: 0)
       }
     }
 
     // Add an isMem parameter for each struct parameter.
-    let dynamicParameters = functionDeclaration.signature.parameters.enumerated().filter { $0.1.type.rawType.isDynamicType }
+    let dynamicParameters = functionDeclaration.signature.parameters.enumerated()
+      .filter { $0.1.type.rawType.isDynamicType }
 
     var offset = 0
     for (index, parameter) in dynamicParameters where !parameter.isImplicit {
-      let isMemParameter = constructParameter(name: Mangler.isMem(for: parameter.identifier.name), type: .basicType(.bool), sourceLocation: parameter.sourceLocation)
+      let isMemParameter = constructParameter(name: Mangler.isMem(for: parameter.identifier.name),
+                                              type: .basicType(.bool),
+                                              sourceLocation: parameter.sourceLocation)
       functionDeclaration.signature.parameters.insert(isMemParameter, at: index + 1 + offset)
       offset += 1
     }
@@ -118,7 +150,8 @@ public struct IRPreprocessor: ASTPass {
     return Parameter(identifier: identifier, type: Type(inferredType: type, identifier: identifier), implicitToken: nil)
   }
 
-  public func process(specialDeclaration: SpecialDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
+  public func process(specialDeclaration: SpecialDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
     var specialDeclaration = specialDeclaration
     if specialDeclaration.isInit {
       specialDeclaration.body.insert(contentsOf: defaultValueAssignments(in: passContext), at: 0)
@@ -131,7 +164,8 @@ public struct IRPreprocessor: ASTPass {
     var becomeStatement = becomeStatement
 
     let enumName = ContractDeclaration.contractEnumPrefix + passContext.enclosingTypeIdentifier!.name
-    let enumReference: Expression = .identifier(Identifier(identifierToken: Token(kind: .identifier(enumName), sourceLocation: becomeStatement.sourceLocation)))
+    let enumReference: Expression = .identifier(
+      Identifier(identifierToken: Token(kind: .identifier(enumName), sourceLocation: becomeStatement.sourceLocation)))
     let state = becomeStatement.expression.assigningEnclosingType(type: enumName)
 
     let dot = Token(kind: .punctuation(.dot), sourceLocation: becomeStatement.sourceLocation)

--- a/Sources/IRGen/Property/IRPropertyAccess.swift
+++ b/Sources/IRGen/Property/IRPropertyAccess.swift
@@ -38,13 +38,13 @@ struct IRPropertyAccess {
       } else {
         fatalError()
       }
-    case .arrayType(_):
+    case .arrayType:
       if case .identifier(let identifier) = rhs, identifier.name == "size" {
         rhsOffset = "0"
       } else {
         fatalError()
       }
-    case .dictionaryType(_):
+    case .dictionaryType:
       if case .identifier(let identifier) = rhs, identifier.name == "size" {
         rhsOffset = "0"
       } else {
@@ -57,18 +57,23 @@ struct IRPropertyAccess {
     let offset: String
     if isInStructFunction {
       let enclosingName: String
-      if let enclosingParameter = functionContext.scopeContext.enclosingParameter(expression: lhs, enclosingTypeName: functionContext.enclosingTypeName) {
+      if let enclosingParameter =
+        functionContext.scopeContext.enclosingParameter(expression: lhs,
+                                                        enclosingTypeName: functionContext.enclosingTypeName) {
         enclosingName = enclosingParameter
       } else {
         enclosingName = "flintSelf"
       }
 
       // For struct parameters, access the property by an offset to _flintSelf (the receiver's address).
-      offset = IRRuntimeFunction.addOffset(base: enclosingName.mangled, offset: rhsOffset, inMemory: Mangler.isMem(for: enclosingName).mangled)
+      offset = IRRuntimeFunction.addOffset(base: enclosingName.mangled,
+                                           offset: rhsOffset,
+                                           inMemory: Mangler.isMem(for: enclosingName).mangled)
     } else {
       let lhsOffset: String
       if case .identifier(let lhsIdentifier) = lhs {
-        if let enclosingType = lhsIdentifier.enclosingType, let offset = environment.propertyOffset(for: lhsIdentifier.name, enclosingType: enclosingType) {
+        if let enclosingType = lhsIdentifier.enclosingType,
+            let offset = environment.propertyOffset(for: lhsIdentifier.name, enclosingType: enclosingType) {
           lhsOffset = "\(offset)"
         } else if functionContext.scopeContext.containsVariableDeclaration(for: lhsIdentifier.name) {
           lhsOffset = lhsIdentifier.name.mangled

--- a/Sources/IRGen/Property/IRPropertyOffset.swift
+++ b/Sources/IRGen/Property/IRPropertyOffset.swift
@@ -13,9 +13,11 @@ struct IRPropertyOffset {
 
   func rendered(functionContext: FunctionContext) -> String {
     if case .binaryExpression(let binaryExpression) = expression {
-      return IRPropertyAccess(lhs: binaryExpression.lhs, rhs: binaryExpression.rhs, asLValue: true).rendered(functionContext: functionContext)
+      return IRPropertyAccess(lhs: binaryExpression.lhs, rhs: binaryExpression.rhs, asLValue: true)
+        .rendered(functionContext: functionContext)
     } else if case .subscriptExpression(let subscriptExpression) = expression {
-      return IRSubscriptExpression(subscriptExpression: subscriptExpression, asLValue: true).rendered(functionContext: functionContext)
+      return IRSubscriptExpression(subscriptExpression: subscriptExpression, asLValue: true)
+        .rendered(functionContext: functionContext)
     }
     guard case .identifier(let identifier) = expression else { fatalError() }
 

--- a/Sources/IRGen/Runtime/IRFunctionSelector.swift
+++ b/Sources/IRGen/Runtime/IRFunctionSelector.swift
@@ -31,9 +31,10 @@ struct IRFunctionSelector {
 
   func renderFallback() -> String {
     if let fallbackDeclaration = fallback {
-      return IRContractFallback(fallbackDeclaration: fallbackDeclaration, typeIdentifier: enclosingType, environment: environment).rendered()
-    }
-    else {
+      return IRContractFallback(fallbackDeclaration: fallbackDeclaration,
+                                typeIdentifier: enclosingType,
+                                environment: environment).rendered()
+    } else {
       return "revert(0, 0)"
     }
   }
@@ -55,11 +56,13 @@ struct IRFunctionSelector {
   func renderCaseBody(function: IRFunction) -> String {
     // Dynamically check that the state is correct for the function to be called.
     let typeStates = function.typeStates
-    let typeStateChecks = IRTypeStateChecks(typeStates: typeStates).rendered(enclosingType: enclosingType.name, environment: environment)
+    let typeStateChecks = IRTypeStateChecks(typeStates: typeStates)
+        .rendered(enclosingType: enclosingType.name, environment: environment)
 
     // Dynamically check the caller has appropriate caller protections.
     let callerProtections = function.callerProtections
-    let callerProtectionChecks = IRCallerProtectionChecks(callerProtections: callerProtections).rendered(enclosingType: enclosingType.name, environment: environment)
+    let callerProtectionChecks = IRCallerProtectionChecks(callerProtections: callerProtections)
+        .rendered(enclosingType: enclosingType.name, environment: environment)
 
     // Dynamically check the function is not being called with value, if it is not payable.
     let valueChecks: String
@@ -81,7 +84,8 @@ struct IRFunctionSelector {
 
     if let resultType = function.resultCanonicalType {
       switch resultType {
-      case .address, .uint256, .bytes32: return typeStateChecks + "\n" + callerProtectionChecks + "\n" + IRRuntimeFunction.return32Bytes(value: call)
+      case .address, .uint256, .bytes32:
+        return typeStateChecks + "\n" + callerProtectionChecks + "\n" + IRRuntimeFunction.return32Bytes(value: call)
       }
     }
 
@@ -97,11 +101,24 @@ struct IRTypeStateChecks {
     let checks = typeStates.compactMap { typeState -> String? in
       guard !typeState.isAny else { return nil }
 
-      let stateValue = IRExpression(expression: environment.getStateValue(typeState.identifier, in: enclosingType), asLValue: false).rendered(functionContext: FunctionContext(environment: environment, scopeContext: ScopeContext(), enclosingTypeName: enclosingType, isInStructFunction: false))
+      let stateValue = IRExpression(expression: environment.getStateValue(typeState.identifier, in: enclosingType),
+                                    asLValue: false)
+        .rendered(functionContext: FunctionContext(environment: environment,
+                                                   scopeContext: ScopeContext(),
+                                                   enclosingTypeName: enclosingType,
+                                                   isInStructFunction: false))
 
-      let stateVariable: Expression = .identifier(Identifier(name: IRContract.stateVariablePrefix + enclosingType, sourceLocation: .DUMMY))
-      let selfState: Expression = .binaryExpression(BinaryExpression(lhs: .self(Token(kind: .self, sourceLocation: .DUMMY)), op: Token(kind: .punctuation(.dot), sourceLocation: .DUMMY), rhs: stateVariable))
-      let stateVariableRendered = IRExpression(expression: selfState, asLValue: false).rendered(functionContext: FunctionContext(environment: environment, scopeContext: ScopeContext(), enclosingTypeName: enclosingType, isInStructFunction: false))
+      let stateVariable: Expression = .identifier(Identifier(name: IRContract.stateVariablePrefix + enclosingType,
+                                                             sourceLocation: .DUMMY))
+      let selfState: Expression = .binaryExpression(BinaryExpression(
+        lhs: .self(Token(kind: .self, sourceLocation: .DUMMY)),
+        op: Token(kind: .punctuation(.dot), sourceLocation: .DUMMY),
+        rhs: stateVariable))
+      let stateVariableRendered = IRExpression(expression: selfState, asLValue: false)
+        .rendered(functionContext: FunctionContext(environment: environment,
+                                                   scopeContext: ScopeContext(),
+                                                   enclosingTypeName: enclosingType,
+                                                   isInStructFunction: false))
 
       let check = IRRuntimeFunction.isMatchingTypeState(stateValue, stateVariableRendered)
       return "_flintStateCheck := add(_flintStateCheck, \(check))"

--- a/Sources/IRGen/Runtime/IRRuntimeFunction.swift
+++ b/Sources/IRGen/Runtime/IRRuntimeFunction.swift
@@ -164,7 +164,6 @@ enum IRRuntimeFunction {
     return "\(Identifiers.power.mangled)(\(b), \(e))"
   }
 
-
   static let allDeclarations: [String] = [
     IRRuntimeFunctionDeclaration.selector,
     IRRuntimeFunctionDeclaration.decodeAsAddress,

--- a/Sources/IRGen/Runtime/IRWrapperFunction.swift
+++ b/Sources/IRGen/Runtime/IRWrapperFunction.swift
@@ -13,7 +13,9 @@ struct IRWrapperFunction {
   let function: IRFunction
 
   func rendered(enclosingType: RawTypeIdentifier) -> String {
-   return rendered(enclosingType: enclosingType, hard: true) + "\n" + rendered(enclosingType: enclosingType, hard: false)
+   return rendered(enclosingType: enclosingType, hard: true) +
+    "\n" +
+    rendered(enclosingType: enclosingType, hard: false)
   }
 
   func rendered(enclosingType: RawTypeIdentifier, hard: Bool) -> String {
@@ -23,14 +25,18 @@ struct IRWrapperFunction {
 
     let invalidCall = hard ? "revert(0, 0)" : "\(IRFunction.returnVariableName) := 0"
 
-    var validCall = hard ? "\(IRFunction.returnVariableName) := \(functionCall)" : "\(functionCall)\n    \(IRFunction.returnVariableName) := 1"
     var returnSignature = "-> \(IRFunction.returnVariableName) "
+
+    let validCall: String
     if hard, function.functionDeclaration.isVoid {
       validCall = functionCall
       returnSignature = ""
-    }
-    if !hard, !function.functionDeclaration.isVoid {
+    } else if !hard, !function.functionDeclaration.isVoid {
       validCall = "\(IRFunction.returnVariableName) := \(functionCall)\n    \(IRFunction.returnVariableName) := 1"
+    } else if hard {
+      validCall = "\(IRFunction.returnVariableName) := \(functionCall)"
+    } else {
+      validCall = "\(functionCall)\n    \(IRFunction.returnVariableName) := 1"
     }
 
     return """
@@ -48,6 +54,7 @@ struct IRWrapperFunction {
   }
 
   func signature(_ hard: Bool) -> String {
-    return "\(hard ? IRWrapperFunction.prefixHard : IRWrapperFunction.prefixSoft)\(function.signature(withReturn: false))"
+    let prefix = hard ? IRWrapperFunction.prefixHard : IRWrapperFunction.prefixSoft
+    return "\(prefix)\(function.signature(withReturn: false))"
   }
 }

--- a/Sources/IRGen/String+Indentation.swift
+++ b/Sources/IRGen/String+Indentation.swift
@@ -8,6 +8,7 @@
 extension String {
   func indented(by level: Int, andFirst: Bool = false) -> String {
     let lines = components(separatedBy: "\n")
-    return ( andFirst ? String(repeating: " ", count: level) : "" ) + lines.joined(separator: "\n" + String(repeating: " ", count: level))
+    let spaces = String(repeating: " ", count: level)
+    return ( andFirst ? spaces : "" ) + lines.joined(separator: "\n" + spaces)
   }
 }

--- a/Sources/Lexer/Lexer.swift
+++ b/Sources/Lexer/Lexer.swift
@@ -18,9 +18,9 @@ public struct Lexer {
 
   var isFromStdlib: Bool
 
-  public init(sourceFile: URL, isFromStdlib: Bool = false) {
+  public init(sourceFile: URL, isFromStdlib: Bool = false) throws {
     self.sourceFile = sourceFile
-    self.sourceCode = try! String(contentsOf: sourceFile)
+    self.sourceCode = try String(contentsOf: sourceFile)
     self.isFromStdlib = isFromStdlib
   }
 
@@ -46,7 +46,8 @@ public struct Lexer {
         // The token is a number literal.
         let lastTwoTokens = tokens[tokens.count-2..<tokens.count]
 
-        if case .literal(.decimal(.integer(let base))) = lastTwoTokens.first!.kind, lastTwoTokens.last!.kind == .punctuation(.dot) {
+        if case .literal(.decimal(.integer(let base))) = lastTwoTokens.first!.kind,
+            lastTwoTokens.last!.kind == .punctuation(.dot) {
           tokens[tokens.count-2] = Token(kind: .literal(.decimal(.real(base, num))), sourceLocation: sourceLocation)
           tokens.removeLast()
         } else {
@@ -58,7 +59,10 @@ public struct Lexer {
         tokens.append(Token(kind: .literal(.address(hex)), sourceLocation: sourceLocation))
       } else if let first = component.first, let last = component.last, first == "\"", first == last {
         // The token is a string literal.
-        tokens.append(Token(kind: .literal(.string(String(component[(component.index(after: component.startIndex)..<component.index(before: component.endIndex))]))), sourceLocation: sourceLocation))
+        let componentSubstring = component[
+            (component.index(after: component.startIndex)..<component.index(before: component.endIndex))
+        ]
+        tokens.append(Token(kind: .literal(.string(String(componentSubstring))), sourceLocation: sourceLocation))
       } else {
         // The token is an identifier.
         tokens.append(Token(kind: .identifier(component), sourceLocation: sourceLocation))

--- a/Sources/Lexer/TokenKind+Punctuation.swift
+++ b/Sources/Lexer/TokenKind+Punctuation.swift
@@ -59,7 +59,9 @@ extension Token.Kind {
 
     static var allBinaryOperators: [Punctuation] {
       return [
-        .plus, .overflowingPlus, .minus, .overflowingMinus, .times, .overflowingTimes, .power, .divide, .equal, .plusEqual, .minusEqual, .timesEqual, .divideEqual, .dot,
+        .plus, .overflowingPlus, .minus, .overflowingMinus, .times, .overflowingTimes, .power, .divide, .equal,
+        .plusEqual, .minusEqual, .timesEqual, .divideEqual, .dot,
+
         .closeAngledBracket, .lessThanOrEqual, .openAngledBracket, .greaterThanOrEqual, .doubleEqual, .notEqual,
         .or, .and
       ]
@@ -73,7 +75,10 @@ extension Token.Kind {
     }
 
     public var isBooleanOperator: Bool {
-      return [.doubleEqual, .notEqual, .lessThanOrEqual, .greaterThanOrEqual, .or, .and, .openAngledBracket, .closeAngledBracket].contains(self)
+      return [
+        .doubleEqual, .notEqual, .lessThanOrEqual, .greaterThanOrEqual,
+        .or, .and, .openAngledBracket, .closeAngledBracket
+        ].contains(self)
     }
 
     var precedence: Int {
@@ -81,7 +86,9 @@ extension Token.Kind {
       case .equal, .plusEqual, .minusEqual, .timesEqual, .divideEqual: return 10
       case .or: return 11
       case .and: return 12
-      case .closeAngledBracket, .lessThanOrEqual, .openAngledBracket, .greaterThanOrEqual, .doubleEqual, .notEqual: return 15
+      case .closeAngledBracket, .openAngledBracket,
+           .lessThanOrEqual, .greaterThanOrEqual, .doubleEqual, .notEqual:
+        return 15
       case .plus, .overflowingPlus: return 20
       case .minus, .overflowingMinus: return 20
       case .times, .overflowingTimes: return 30

--- a/Sources/Parser/Parser+Components.swift
+++ b/Sources/Parser/Parser+Components.swift
@@ -15,12 +15,12 @@ extension Parser {
       throw raise(.expectedIdentifier(at: latestSource))
     }
     switch token.kind {
-      case .identifier(_), .self:
-        currentIndex += 1
-        consumeNewLines()
-        return Identifier(identifierToken: token)
-      default:
-        throw raise(.expectedIdentifier(at: latestSource))
+    case .identifier, .self:
+      currentIndex += 1
+      consumeNewLines()
+      return Identifier(identifierToken: token)
+    default:
+      throw raise(.expectedIdentifier(at: latestSource))
     }
 
   }
@@ -76,8 +76,7 @@ extension Parser {
     while let first = currentToken?.kind {
       if modifierTokens.contains(first) {
         modifiers.append(try consume(anyOf: modifierTokens, or: .expectedModifier(at: latestSource)))
-      }
-      else {
+      } else {
         break
       }
     }
@@ -104,7 +103,8 @@ extension Parser {
     }
 
     while currentIndex < closingIndex {
-      guard let elementEnd = indexOfFirstAtCurrentDepth([.punctuation(.comma), .punctuation(.closeSquareBracket)]) else {
+      guard let elementEnd = indexOfFirstAtCurrentDepth([.punctuation(.comma),
+                                                         .punctuation(.closeSquareBracket)]) else {
         throw raise(.expectedSeparator(at: latestSource))
       }
       let element = try parseExpression(upTo: elementEnd)
@@ -113,9 +113,12 @@ extension Parser {
         try consume(.punctuation(.comma), or: .expectedSeparator(at: latestSource))
       }
     }
-    let closeSquareBracket = try consume(.punctuation(.closeSquareBracket), or: .expectedCloseSquareArrayLiteral(at: latestSource))
+    let closeSquareBracket = try consume(.punctuation(.closeSquareBracket),
+                                         or: .expectedCloseSquareArrayLiteral(at: latestSource))
 
-    return ArrayLiteral(openSquareBracketToken: openSquareBracket, elements: elements, closeSquareBracketToken: closeSquareBracket)
+    return ArrayLiteral(openSquareBracketToken: openSquareBracket,
+                        elements: elements,
+                        closeSquareBracketToken: closeSquareBracket)
   }
 
   // MARK: Parameters
@@ -128,7 +131,7 @@ extension Parser {
     }
 
     while currentIndex < closingIndex {
-      var implicitToken: Token? = nil
+      var implicitToken: Token?
       if currentToken?.kind == .implicit {
         implicitToken = try consume(.implicit, or: .dummy())
       }
@@ -142,7 +145,8 @@ extension Parser {
         try consume(.punctuation(.comma), or: .expectedSeparator(at: latestSource))
       }
     }
-    let closeBracketToken = try consume(.punctuation(.closeBracket), or: .expectedParameterCloseParenthesis(at: latestSource))
+    let closeBracketToken = try consume(.punctuation(.closeBracket),
+                                        or: .expectedParameterCloseParenthesis(at: latestSource))
 
     return (parameters, closeBracketToken)
   }
@@ -166,7 +170,8 @@ extension Parser {
   // MARK: Conformances
   func parseConformances() throws -> [Conformance] {
     try consume(.punctuation(.colon), or: .expectedConformance(at: latestSource))
-    guard let endOfConformances = indexOfFirstAtCurrentDepth([.punctuation(.openBracket), .newline, .punctuation(.openBrace)]) else {
+    guard let endOfConformances = indexOfFirstAtCurrentDepth([.punctuation(.openBracket),
+                                                              .newline, .punctuation(.openBrace)]) else {
       throw raise(.expectedConformance(at: latestSource))
     }
     let identifiers = try parseIdentifierList(upTo: endOfConformances)
@@ -185,18 +190,26 @@ extension Parser {
 
   // MARK: Type
   func parseType() throws -> Type {
-    if let openSquareBracketToken = attempt(try consume(.punctuation(.openSquareBracket), or: .expectedType(at: latestSource))) {
+    if let openSquareBracketToken = attempt(try consume(.punctuation(.openSquareBracket),
+                                                        or: .expectedType(at: latestSource))) {
       // The type is an array type or a dictionary type.
       let keyType = try parseType()
       if attempt(try consume(.punctuation(.colon), or: .expectedColonDictionaryLiteral(at: latestSource))) != nil {
         // The type is a dictionary type.
         let valueType = try parseType()
-        let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket), or: .expectedCloseSquareDictionaryLiteral(at: latestSource))
-        return Type(openSquareBracketToken: openSquareBracketToken, dictionaryWithKeyType: keyType, valueType: valueType, closeSquareBracketToken: closeSquareBracketToken)
+        let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket),
+                                                  or: .expectedCloseSquareDictionaryLiteral(at: latestSource))
+        return Type(openSquareBracketToken: openSquareBracketToken,
+                    dictionaryWithKeyType: keyType,
+                    valueType: valueType,
+                    closeSquareBracketToken: closeSquareBracketToken)
       }
 
-      let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket), or: .expectedCloseSquareArrayType(at: latestSource))
-      return Type(openSquareBracketToken: openSquareBracketToken, arrayWithElementType: keyType, closeSquareBracketToken: closeSquareBracketToken)
+      let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket),
+                                                or: .expectedCloseSquareArrayType(at: latestSource))
+      return Type(openSquareBracketToken: openSquareBracketToken,
+                  arrayWithElementType: keyType,
+                  closeSquareBracketToken: closeSquareBracketToken)
     }
 
     if let inoutToken = attempt(try consume(.inout, or: .dummy())) {
@@ -219,7 +232,8 @@ extension Parser {
         throw raise(.expectedIntegerInFixedArrayType(at: latestSource))
       }
 
-      let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket), or: .expectedCloseSquareArrayType(at: latestSource))
+      let closeSquareBracketToken = try consume(.punctuation(.closeSquareBracket),
+                                                or: .expectedCloseSquareArrayType(at: latestSource))
       return Type(fixedSizeArrayWithElementType: type, size: size, closeSquareBracketToken: closeSquareBracketToken)
     }
 

--- a/Sources/Parser/Parser+Declaration.swift
+++ b/Sources/Parser/Parser+Declaration.swift
@@ -44,7 +44,7 @@ extension Parser {
       case .enum:
         let enumDeclaration = try parseEnumDeclaration()
         declarations.append(.enumDeclaration(enumDeclaration))
-      case .identifier(_), .self:
+      case .identifier, .self:
         let contractBehaviorDeclaration = try parseContractBehaviorDeclaration()
         declarations.append(.contractBehaviorDeclaration(contractBehaviorDeclaration))
       default:
@@ -78,7 +78,11 @@ extension Parser {
     let members = try parseContractMembers(enclosingType: identifier.name)
     try consume(.punctuation(.closeBrace), or: .rightBraceExpected(in: "contract declaration", at: latestSource))
 
-    return ContractDeclaration(contractToken: contractToken, identifier: identifier, conformances: conformances, states: states, members: members)
+    return ContractDeclaration(contractToken: contractToken,
+                               identifier: identifier,
+                               conformances: conformances,
+                               states: states,
+                               members: members)
   }
 
   func parseStructDeclaration() throws -> StructDeclaration {
@@ -92,7 +96,10 @@ extension Parser {
     let members = try parseStructMembers(structIdentifier: identifier)
     try consume(.punctuation(.closeBrace), or: .rightBraceExpected(in: "struct declaration", at: latestSource))
 
-    return StructDeclaration(structToken: structToken, identifier: identifier, conformances: conformances, members: members)
+    return StructDeclaration(structToken: structToken,
+                             identifier: identifier,
+                             conformances: conformances,
+                             members: members)
   }
 
   func parseEnumDeclaration() throws -> EnumDeclaration {
@@ -136,10 +143,10 @@ extension Parser {
     let contractIdentifier = try parseIdentifier()
 
     var states: [TypeState] = []
-    var callerBinding: Identifier? = nil
+    var callerBinding: Identifier?
 
     if currentToken?.kind == .punctuation(.at) {
-      let _ = try consume(.punctuation(.at), or: .dummy())
+      _ = try consume(.punctuation(.at), or: .dummy())
       states = try parseTypeStateGroup()
     }
 
@@ -155,7 +162,12 @@ extension Parser {
 
     try consume(.punctuation(.closeBrace), or: .rightBraceExpected(in: "contract behavior", at: latestSource))
 
-    return ContractBehaviorDeclaration(contractIdentifier: contractIdentifier, states: states, callerBinding: callerBinding, callerProtections: callerProtections, closeBracketToken: closeBracketToken, members: members)
+    return ContractBehaviorDeclaration(contractIdentifier: contractIdentifier,
+                                       states: states,
+                                       callerBinding: callerBinding,
+                                       callerProtections: callerProtections,
+                                       closeBracketToken: closeBracketToken,
+                                       members: members)
   }
 
   // MARK: Top Level Members
@@ -178,7 +190,9 @@ extension Parser {
         guard let newLine = indexOfFirstAtCurrentDepth([.newline]) else {
           throw raise(.statementSameLine(at: latestSource))
         }
-        let decl = try parseVariableDeclaration(modifiers: modifiers, enclosingType: structIdentifier.name, upTo: newLine)
+        let decl = try parseVariableDeclaration(modifiers: modifiers,
+                                                enclosingType: structIdentifier.name,
+                                                upTo: newLine)
         members.append(.variableDeclaration(decl))
       } else if first == .punctuation(.closeBrace) {
         return members
@@ -206,12 +220,16 @@ extension Parser {
     let caseToken = try consume(.case, or: .expectedEnumDeclarationCaseMember(at: latestSource))
     var identifier = try parseIdentifier()
     identifier.enclosingType = enumIdentifier.name
-    var hiddenValue: Expression? = nil
+    var hiddenValue: Expression?
     if currentToken?.kind == .punctuation(.equal) {
-      let _ = try consume(.punctuation(.equal), or: .dummy())
+      _ = try consume(.punctuation(.equal), or: .dummy())
       hiddenValue = try parseExpression(upTo: indexOfFirstAtCurrentDepth([.newline])!)
     }
-    return EnumMember(caseToken: caseToken, identifier: identifier, type: Type(identifier: enumIdentifier), hiddenValue: hiddenValue, hiddenType: hiddenType)
+    return EnumMember(caseToken: caseToken,
+                      identifier: identifier,
+                      type: Type(identifier: enumIdentifier),
+                      hiddenValue: hiddenValue,
+                      hiddenType: hiddenType)
   }
 
   func parseTraitMembers() throws -> [TraitMember] {
@@ -233,12 +251,12 @@ extension Parser {
     }
 
     switch first {
-      case .event:
-        return .eventDeclaration(try parseEventDeclaration())
-      case .self, .identifier(_):
-        return .contractBehaviourDeclaration(try parseContractBehaviorDeclaration())
-      default:
-        break
+    case .event:
+      return .eventDeclaration(try parseEventDeclaration())
+    case .self, .identifier:
+      return .contractBehaviourDeclaration(try parseContractBehaviorDeclaration())
+    default:
+      break
     }
 
     let attrs = try parseAttributes()
@@ -256,13 +274,15 @@ extension Parser {
     let declType = currentToken?.kind
     if .func == declType {
       if signatureDeclaration {
-        return .functionSignatureDeclaration(try parseFunctionSignatureDeclaration(attributes: attrs, modifiers: modifiers))
+        return .functionSignatureDeclaration(
+          try parseFunctionSignatureDeclaration(attributes: attrs, modifiers: modifiers))
       } else {
         return .functionDeclaration(try parseFunctionDeclaration(attributes: attrs, modifiers: modifiers))
       }
     } else if .init == declType {
       if signatureDeclaration {
-        return .specialSignatureDeclaration(try parseSpecialSignatureDeclaration(attributes: attrs, modifiers: modifiers))
+        return .specialSignatureDeclaration(
+          try parseSpecialSignatureDeclaration(attributes: attrs, modifiers: modifiers))
       } else {
         return .specialDeclaration(try parseSpecialDeclaration(attributes: attrs, modifiers: modifiers))
       }
@@ -276,12 +296,12 @@ extension Parser {
 
     while let first = currentToken?.kind {
       switch first {
-        case .func, .init, .fallback, .public, .visible, .mutating, .punctuation(.at):
-          members.append(try parseContractBehaviorMember(enclosingType: contractIdentifier))
-        case .punctuation(.closeBrace):
-          return members
-        default:
-          throw raise(.badMember(in: "contract behaviour", at: latestSource))
+      case .func, .init, .fallback, .public, .visible, .mutating, .punctuation(.at):
+        members.append(try parseContractBehaviorMember(enclosingType: contractIdentifier))
+      case .punctuation(.closeBrace):
+        return members
+      default:
+        throw raise(.badMember(in: "contract behaviour", at: latestSource))
       }
     }
     throw raise(.unexpectedEOF())
@@ -305,14 +325,16 @@ extension Parser {
 
     if .func == first {
       if signatureDeclaration {
-        return .functionSignatureDeclaration(try parseFunctionSignatureDeclaration(attributes: attrs, modifiers: modifiers))
+        return .functionSignatureDeclaration(
+          try parseFunctionSignatureDeclaration(attributes: attrs, modifiers: modifiers))
       }
       return .functionDeclaration(try parseFunctionDeclaration(attributes: attrs, modifiers: modifiers))
     }
 
     if .init == first  || .fallback == first {
       if signatureDeclaration {
-        return .specialSignatureDeclaration(try parseSpecialSignatureDeclaration(attributes: attrs, modifiers: modifiers))
+        return .specialSignatureDeclaration(
+          try parseSpecialSignatureDeclaration(attributes: attrs, modifiers: modifiers))
       }
       return .specialDeclaration(try parseSpecialDeclaration(attributes: attrs, modifiers: modifiers))
     }
@@ -347,7 +369,9 @@ extension Parser {
     guard let newLine = indexOfFirstAtCurrentDepth([.newline]) else {
       throw raise(.statementSameLine(at: latestSource))
     }
-    let variableDeclaration = try parseVariableDeclaration(modifiers: modifiers, enclosingType: enclosingType, upTo: newLine)
+    let variableDeclaration = try parseVariableDeclaration(modifiers: modifiers,
+                                                           enclosingType: enclosingType,
+                                                           upTo: newLine)
     return .variableDeclaration(variableDeclaration)
 
   }
@@ -363,8 +387,7 @@ extension Parser {
         }
         let decl = try parseVariableDeclaration(modifiers: modifiers, enclosingType: enclosingType, upTo: newLine)
         variableDeclarations.append(decl)
-      }
-      else {
+      } else {
         break
       }
     }
@@ -380,7 +403,9 @@ extension Parser {
   /// - Parameter enclosingType: The name of the type in which the variable is declared, if it is a state property.
   /// - Returns: The parsed `VariableDeclaration`.
   /// - Throws: If the token streams cannot be parsed as a `VariableDeclaration`.
-  func parseVariableDeclaration(modifiers: [Token], enclosingType: RawTypeIdentifier? = nil, upTo: Int) throws -> VariableDeclaration {
+  func parseVariableDeclaration(modifiers: [Token],
+                                enclosingType: RawTypeIdentifier? = nil,
+                                upTo: Int) throws -> VariableDeclaration {
 
     let declarationToken = try consume(anyOf: [.var, .let], or: .badDeclaration(at: latestSource))
 
@@ -398,9 +423,10 @@ extension Parser {
     if currentIndex >= upTo {
       assignedExpression = nil
     } else if currentToken?.kind == .punctuation(.equal) {
-      // If we are parsing a state property defined in a type, and it has been assigned a default value, parse it otherwise leave it to binary expression
+      // If we are parsing a state property defined in a type, and it has been assigned a default value,
+      // parse it otherwise leave it to binary expression
       if asTypeProperty {
-        let _ = try consume(.punctuation(.equal), or: .expectedValidOperator(at: latestSource))
+        _ = try consume(.punctuation(.equal), or: .expectedValidOperator(at: latestSource))
         assignedExpression = try parseExpression(upTo: upTo)
       } else {
         assignedExpression = nil
@@ -409,7 +435,11 @@ extension Parser {
       throw raise(.expectedValidOperator(at: latestSource))
     }
 
-    return VariableDeclaration(modifiers: modifiers, declarationToken: declarationToken, identifier: name, type: typeAnnotation.type, assignedExpression: assignedExpression)
+    return VariableDeclaration(modifiers: modifiers,
+                               declarationToken: declarationToken,
+                               identifier: name,
+                               type: typeAnnotation.type,
+                               assignedExpression: assignedExpression)
   }
 
   func parseResult() throws -> Type {
@@ -425,7 +455,8 @@ extension Parser {
     return FunctionDeclaration(signature: signature, body: body, closeBraceToken: closeBraceToken)
   }
 
-  func parseFunctionSignatureDeclaration(attributes: [Attribute], modifiers: [Token]) throws -> FunctionSignatureDeclaration {
+  func parseFunctionSignatureDeclaration(attributes: [Attribute],
+                                         modifiers: [Token]) throws -> FunctionSignatureDeclaration {
     let funcToken = try consume(.func, or: .badDeclaration(at: latestSource))
     let identifier = try parseIdentifier()
     let (parameters, closeBracketToken) = try parseParameters()
@@ -453,7 +484,8 @@ extension Parser {
     return SpecialDeclaration(signature: signature, body: body, closeBraceToken: closeBraceToken)
   }
 
-  func parseSpecialSignatureDeclaration(attributes: [Attribute], modifiers: [Token]) throws -> SpecialSignatureDeclaration {
+  func parseSpecialSignatureDeclaration(attributes: [Attribute],
+                                        modifiers: [Token]) throws -> SpecialSignatureDeclaration {
     let specialToken: Token = try consume(anyOf: [.init, .fallback], or: .badDeclaration(at: latestSource))
     let (parameters, closeBracketToken) = try parseParameters()
 

--- a/Sources/Parser/Parser+Utils.swift
+++ b/Sources/Parser/Parser+Utils.swift
@@ -38,8 +38,8 @@ extension Parser {
     return first
   }
 
-  /// Consumes one of the given tokens from the given list, i.e. discard it and move on to the next one. Throws if the current
-  /// token being processed isn't equal to any of the given tokens.
+  /// Consumes one of the given tokens from the given list, i.e. discard it and move on to the next one. Throws if the
+  /// current token being processed isn't equal to any of the given tokens.
   ///
   /// - Parameters:
   ///   - tokens: The tokens that can be consumed.

--- a/Sources/Parser/ParserError.swift
+++ b/Sources/Parser/ParserError.swift
@@ -47,7 +47,8 @@ extension Diagnostic {
 
   // MARK: Operators
   static func expectedValidOperator(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected operator in binary expression")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Expected operator in binary expression")
   }
 
   // MARK: Contract
@@ -57,13 +58,16 @@ extension Diagnostic {
 
   // MARK: Statement
   static func expectedStatement(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected statement")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Expected statement")
   }
   static func expectedForInStatement(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected 'in' between variable declaration and iterable")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Expected 'in' between variable declaration and iterable")
   }
   static func statementSameLine(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Statements must be separated by a new line ")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Statements must be separated by a new line ")
   }
 
   // MARK: Components
@@ -86,7 +90,8 @@ extension Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected type annotation")
   }
   static func expectedConformance(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected a trait identifier to conform to")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Expected a trait identifier to conform to")
   }
 
   // MARK: Enum
@@ -104,7 +109,8 @@ extension Diagnostic {
 
   // MARK: Expressions
   static func expectedCloseParen(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected ')' for bracketed expression")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Expected ')' for bracketed expression")
   }
   static func expectedColonAfterArgumentLabel(at sourceLocation: SourceLocation) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected ':' after argument label")
@@ -113,16 +119,19 @@ extension Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected expression")
   }
   static func expectedSort(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected the try to be specified with '!' or '?'")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Expected the try to be specified with '!' or '?'")
   }
   static func expectedRangeOperator(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected '...' or '..<' for setting range type")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Expected '...' or '..<' for setting range type")
   }
   static func expectedCloseSquareSubscript(at sourceLocation: SourceLocation) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected ']' in subscript expression")
   }
   static func expectedCloseSquareDictionaryLiteral(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected ']' in dictionary literal expression")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Expected ']' in dictionary literal expression")
   }
   static func expectedColonDictionaryLiteral(at sourceLocation: SourceLocation) -> Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected ':' in dictionary literal")
@@ -134,7 +143,8 @@ extension Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected ',' in list")
   }
   static func expectedEndAfterInout(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected ',' or ')' after inout identifier")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Expected ',' or ')' after inout identifier")
   }
 
   // MARK: Generics
@@ -150,6 +160,7 @@ extension Diagnostic {
     return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected ']' in array type")
   }
   static func expectedIntegerInFixedArrayType(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Expected an integer in fixed array type")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Expected an integer in fixed array type")
   }
 }

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer+Declarations.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer+Declarations.swift
@@ -11,7 +11,8 @@ import Diagnostic
 extension SemanticAnalyzer {
 
   // MARK: Contract
-  public func process(contractDeclaration: ContractDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration> {
+  public func process(contractDeclaration: ContractDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<ContractDeclaration> {
     var diagnostics = [Diagnostic]()
     let environment = passContext.environment!
     if let conflict = environment.conflictingTypeDeclaration(for: contractDeclaration.identifier) {
@@ -27,16 +28,16 @@ extension SemanticAnalyzer {
     }
 
     let conflictingSignatures = environment.conflictingTraitSignatures(for: contractDeclaration.identifier.name)
-    conflictingSignatures.forEach { (functionName, functions) in
+    conflictingSignatures.forEach { (_, functions) in
       diagnostics.append(.traitsAreIncompatible(contractDeclaration, functions))
     }
-
 
     return ASTPassResult(element: contractDeclaration, diagnostics: diagnostics, passContext: passContext)
   }
 
   // MARK: Struct
-  public func process(structDeclaration: StructDeclaration, passContext: ASTPassContext) -> ASTPassResult<StructDeclaration> {
+  public func process(structDeclaration: StructDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<StructDeclaration> {
     var diagnostics = [Diagnostic]()
     let environment = passContext.environment!
     let structName = structDeclaration.identifier.name
@@ -56,14 +57,15 @@ extension SemanticAnalyzer {
     }
 
     let conflictingSignatures = environment.conflictingTraitSignatures(for: structDeclaration.identifier.name)
-    conflictingSignatures.forEach { (functionName, functions) in
+    conflictingSignatures.forEach { (_, functions) in
       diagnostics.append(.traitsAreIncompatible(structDeclaration, functions))
     }
 
     return ASTPassResult(element: structDeclaration, diagnostics: diagnostics, passContext: passContext)
   }
 
-  public func postProcess(structDeclaration: StructDeclaration, passContext: ASTPassContext) -> ASTPassResult<StructDeclaration> {
+  public func postProcess(structDeclaration: StructDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<StructDeclaration> {
     var diagnostics = [Diagnostic]()
     // Check that all trait functions are defined
     let functions = passContext.environment!.undefinedFunctions(in: structDeclaration.identifier)
@@ -79,7 +81,6 @@ extension SemanticAnalyzer {
     return ASTPassResult(element: structDeclaration, diagnostics: diagnostics, passContext: passContext)
   }
 
-
   func isConformanceRepeated(_ conformances: [Conformance]) -> Bool {
     return conformances.reduce(into: [String: [Conformance]]()) {
       $0[$1.identifier.name, default: []].append($1)
@@ -87,15 +88,18 @@ extension SemanticAnalyzer {
   }
 
   // MARK: Contract Behaviour
-  public func process(contractBehaviorDeclaration: ContractBehaviorDeclaration, passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration> {
+  public func process(contractBehaviorDeclaration: ContractBehaviorDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<ContractBehaviorDeclaration> {
     var diagnostics = [Diagnostic]()
 
     let environment = passContext.environment!
 
-    if !environment.isContractDeclared(contractBehaviorDeclaration.contractIdentifier.name), contractBehaviorDeclaration.contractIdentifier.name != "self" {
+    if !environment.isContractDeclared(contractBehaviorDeclaration.contractIdentifier.name),
+      contractBehaviorDeclaration.contractIdentifier.name != "self" {
       // The contract behavior declaration could not be associated with any contract declaration.
       diagnostics.append(.contractBehaviorDeclarationNoMatchingContract(contractBehaviorDeclaration))
-    } else if environment.isStateful(contractBehaviorDeclaration.contractIdentifier.name) != (contractBehaviorDeclaration.states != []) {
+    } else if environment.isStateful(contractBehaviorDeclaration.contractIdentifier.name) !=
+      (contractBehaviorDeclaration.states != []) {
       // The statefullness of the contract declaration and contract behavior declaration do not match.
       diagnostics.append(.contractBehaviorDeclarationMismatchedStatefulness(contractBehaviorDeclaration))
     }
@@ -104,19 +108,22 @@ extension SemanticAnalyzer {
     if passContext.traitDeclarationContext == nil {
       contractBehaviorDeclaration.members.forEach { member in
         switch member {
-          case .functionDeclaration(_), .specialDeclaration(_):
-            break
-          case .functionSignatureDeclaration(let decl):
-            diagnostics.append(.signatureInContract(at: decl.sourceLocation))
-          case .specialSignatureDeclaration(let decl):
-            diagnostics.append(.signatureInContract(at: decl.sourceLocation))
+        case .functionDeclaration, .specialDeclaration:
+          break
+        case .functionSignatureDeclaration(let decl):
+          diagnostics.append(.signatureInContract(at: decl.sourceLocation))
+        case .specialSignatureDeclaration(let decl):
+          diagnostics.append(.signatureInContract(at: decl.sourceLocation))
         }
       }
     }
 
     // Create a context containing the contract the methods are defined for, and the caller protections the functions
     // within it are scoped by.
-    let declarationContext = ContractBehaviorDeclarationContext(contractIdentifier: contractBehaviorDeclaration.contractIdentifier, typeStates: contractBehaviorDeclaration.states, callerProtections: contractBehaviorDeclaration.callerProtections)
+    let declarationContext =
+      ContractBehaviorDeclarationContext(contractIdentifier: contractBehaviorDeclaration.contractIdentifier,
+                                         typeStates: contractBehaviorDeclaration.states,
+                                         callerProtections: contractBehaviorDeclaration.callerProtections)
 
     let passContext = passContext.withUpdates { $0.contractBehaviorDeclarationContext = declarationContext }
 
@@ -124,18 +131,21 @@ extension SemanticAnalyzer {
   }
 
   // MARK: Events
-  public func process(eventDeclaration: EventDeclaration, passContext: ASTPassContext) -> ASTPassResult<EventDeclaration> {
+  public func process(eventDeclaration: EventDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<EventDeclaration> {
     var diagnostics = [Diagnostic]()
     let enclosingType = passContext.enclosingTypeIdentifier!.name
 
-    if let conflict = passContext.environment!.conflictingEventDeclaration(for: eventDeclaration.identifier, in: enclosingType) {
+    if let conflict = passContext.environment!.conflictingEventDeclaration(for: eventDeclaration.identifier,
+                                                                           in: enclosingType) {
       diagnostics.append(.invalidRedeclaration(eventDeclaration.identifier, originalSource: conflict))
     }
     return ASTPassResult(element: eventDeclaration, diagnostics: diagnostics, passContext: passContext)
   }
 
   // MARK: Traits
-  public func process(traitDeclaration: TraitDeclaration, passContext: ASTPassContext) -> ASTPassResult<TraitDeclaration> {
+  public func process(traitDeclaration: TraitDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<TraitDeclaration> {
     var diagnostics = [Diagnostic]()
     let environment = passContext.environment!
 
@@ -175,14 +185,14 @@ extension SemanticAnalyzer {
     var diagnostics = [Diagnostic]()
     let environment = passContext.environment!
 
-    if let conflict = environment.conflictingPropertyDeclaration(for: enumCase.identifier, in: enumCase.type.rawType.name) {
+    if let conflict = environment.conflictingPropertyDeclaration(for: enumCase.identifier,
+                                                                 in: enumCase.type.rawType.name) {
       diagnostics.append(.invalidRedeclaration(enumCase.identifier, originalSource: conflict))
     }
 
     if enumCase.hiddenValue == nil {
       diagnostics.append(.cannotInferHiddenValue(enumCase.identifier, enumCase.hiddenType))
-    }
-    else if case .literal(_)? = enumCase.hiddenValue {} else {
+    } else if case .literal(_)? = enumCase.hiddenValue {} else {
       diagnostics.append(.invalidHiddenValue(enumCase))
     }
 
@@ -191,10 +201,10 @@ extension SemanticAnalyzer {
 
   func isContractTraitMember(member: TraitMember) -> Bool {
     switch member {
-    case .contractBehaviourDeclaration(_), .eventDeclaration(_):
+    case .contractBehaviourDeclaration, .eventDeclaration:
       return true
-    case .functionDeclaration(_), .specialDeclaration(_),
-         .functionSignatureDeclaration(_), .specialSignatureDeclaration(_):
+    case .functionDeclaration, .specialDeclaration,
+         .functionSignatureDeclaration, .specialSignatureDeclaration:
       return false
     }
   }
@@ -203,9 +213,9 @@ extension SemanticAnalyzer {
     return !isContractTraitMember(member: member)
   }
 
-
   // MARK: Variable
-  public func process(variableDeclaration: VariableDeclaration, passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration> {
+  public func process(variableDeclaration: VariableDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<VariableDeclaration> {
     var passContext = passContext
     var diagnostics = [Diagnostic]()
     let environment = passContext.environment!
@@ -214,8 +224,7 @@ extension SemanticAnalyzer {
      if variableDeclaration.isMutating {
        if variableDeclaration.isConstant {
           diagnostics.append(.mutatingConstant(variableDeclaration))
-       }
-       else if variableDeclaration.isVariable {
+       } else if variableDeclaration.isVariable {
           diagnostics.append(.mutatingVariable(variableDeclaration))
        }
      }
@@ -230,7 +239,8 @@ extension SemanticAnalyzer {
      }
 
     // Ensure that the type is declared.
-    if case .userDefinedType(let typeIdentifier) = variableDeclaration.type.rawType, !environment.isTypeDeclared(typeIdentifier) {
+    if case .userDefinedType(let typeIdentifier) = variableDeclaration.type.rawType,
+      !environment.isTypeDeclared(typeIdentifier) {
       diagnostics.append(.useOfUndeclaredType(variableDeclaration.type))
     }
 
@@ -244,7 +254,8 @@ extension SemanticAnalyzer {
       passContext.scopeContext?.localVariables += [variableDeclaration]
     } else if let enclosingType = passContext.enclosingTypeIdentifier?.name {
       // It's a property declaration.
-      if let conflict = environment.conflictingPropertyDeclaration(for: variableDeclaration.identifier, in: enclosingType) {
+      if let conflict = environment.conflictingPropertyDeclaration(for: variableDeclaration.identifier,
+                                                                   in: enclosingType) {
         diagnostics.append(.invalidRedeclaration(variableDeclaration.identifier, originalSource: conflict))
       }
 
@@ -252,8 +263,9 @@ extension SemanticAnalyzer {
       let isInitializerDeclared: Bool
 
       if let contractStateDeclarationContext = passContext.contractStateDeclarationContext {
-        isInitializerDeclared = environment.publicInitializer(forContract: contractStateDeclarationContext.contractIdentifier.name) != nil
-      } else if let structName = passContext.structDeclarationContext?.structIdentifier.name{
+        isInitializerDeclared =
+          environment.publicInitializer(forContract: contractStateDeclarationContext.contractIdentifier.name) != nil
+      } else if let structName = passContext.structDeclarationContext?.structIdentifier.name {
         isInitializerDeclared = environment.initializers(in: structName).count > 0
       } else {
         isInitializerDeclared = false
@@ -263,7 +275,8 @@ extension SemanticAnalyzer {
 
       // If a default value is assigned, it should not refer to another property.
 
-      if variableDeclaration.assignedExpression == nil, !isInitializerDeclared, passContext.eventDeclarationContext == nil {
+      if variableDeclaration.assignedExpression == nil, !isInitializerDeclared,
+        passContext.eventDeclarationContext == nil {
         // The contract has no public initializer, so a default value must be provided.
 
         diagnostics.append(.statePropertyIsNotAssignedAValue(variableDeclaration))
@@ -280,11 +293,13 @@ extension SemanticAnalyzer {
   }
 
   // MARK: Function
-  public func process(functionDeclaration: FunctionDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
+  public func process(functionDeclaration: FunctionDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
     var diagnostics = [Diagnostic]()
 
     let enclosingType = passContext.enclosingTypeIdentifier!.name
-    if let conflict = passContext.environment!.conflictingFunctionDeclaration(for: functionDeclaration, in: enclosingType) {
+    if let conflict = passContext.environment!.conflictingFunctionDeclaration(for: functionDeclaration,
+                                                                              in: enclosingType) {
       diagnostics.append(.invalidRedeclaration(functionDeclaration.identifier, originalSource: conflict))
     }
 
@@ -292,7 +307,8 @@ extension SemanticAnalyzer {
     let implicitParameters = signature.parameters.filter { $0.isImplicit }
     let payableValueParameters = signature.parameters.filter { $0.isPayableValueParameter }
     if functionDeclaration.isPayable {
-      // If a function is marked with the @payable annotation, ensure it contains one compatible payable parameter, and no other implicit parameters.
+      // If a function is marked with the @payable annotation, ensure it contains one compatible payable parameter,
+      // and no other implicit parameters.
       if payableValueParameters.count > 1 {
         // If too many arguments are compatible, emit an error.
         diagnostics.append(.ambiguousPayableValueParameter(functionDeclaration))
@@ -313,7 +329,8 @@ extension SemanticAnalyzer {
     if functionDeclaration.isPublic {
       let dynamicParameters = signature.parameters.filter { $0.type.rawType.isDynamicType && !$0.isImplicit }
       if !dynamicParameters.isEmpty {
-        diagnostics.append(.useOfDynamicParamaterInFunctionDeclaration(functionDeclaration, dynamicParameters: dynamicParameters))
+        diagnostics.append(.useOfDynamicParamaterInFunctionDeclaration(functionDeclaration,
+                                                                       dynamicParameters: dynamicParameters))
       }
     }
 
@@ -344,7 +361,8 @@ extension SemanticAnalyzer {
     if returns.isEmpty,
       let resultType = functionDeclaration.signature.resultType {
       // Emit an error if a non-void function doesn't have a return statement.
-      diagnostics.append(.missingReturnInNonVoidFunction(closeBraceToken: functionDeclaration.closeBraceToken, resultType: resultType))
+      diagnostics.append(.missingReturnInNonVoidFunction(closeBraceToken: functionDeclaration.closeBraceToken,
+                                                         resultType: resultType))
     }
 
     // Check becomes are after returns
@@ -372,7 +390,8 @@ extension SemanticAnalyzer {
     return ASTPassResult(element: functionDeclaration, diagnostics: diagnostics, passContext: passContext)
   }
 
-  public func postProcess(functionDeclaration: FunctionDeclaration, passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
+  public func postProcess(functionDeclaration: FunctionDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<FunctionDeclaration> {
     // Called after all the statements in a function have been visited.
 
     let mutatingExpressions = passContext.mutatingExpressions ?? []
@@ -380,7 +399,8 @@ extension SemanticAnalyzer {
     let environment = passContext.environment!
     var diagnostics = [Diagnostic]()
 
-    if functionDeclaration.isMutating, mutatingExpressions.isEmpty, !environment.isConforming(functionDeclaration, in: enclosingType) {
+    if functionDeclaration.isMutating, mutatingExpressions.isEmpty,
+      !environment.isConforming(functionDeclaration, in: enclosingType) {
       // The function is declared mutating but its body does not contain any mutating expression.
       diagnostics.append(.functionCanBeDeclaredNonMutating(functionDeclaration.mutatingToken))
     }
@@ -393,9 +413,9 @@ extension SemanticAnalyzer {
     return ASTPassResult(element: functionDeclaration, diagnostics: diagnostics, passContext: passContext)
   }
 
-
   // MARK: Special
-  public func process(specialDeclaration: SpecialDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
+  public func process(specialDeclaration: SpecialDeclaration,
+                      passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
     let enclosingType = passContext.enclosingTypeIdentifier!.name
     let environment = passContext.environment!
     var diagnostics = [Diagnostic]()
@@ -404,7 +424,9 @@ extension SemanticAnalyzer {
       if !specialDeclaration.signature.parameters.isEmpty {
         diagnostics.append(.fallbackDeclaredWithArguments(specialDeclaration))
       }
-      let complexStatements = specialDeclaration.body.filter({isComplexStatement($0, env: environment, enclosingType: enclosingType)})
+      let complexStatements = specialDeclaration.body.filter({
+        isComplexStatement($0, env: environment, enclosingType: enclosingType)
+      })
       if !complexStatements.isEmpty || specialDeclaration.body.count > 2 {
         diagnostics.append(.fallbackShouldBeSimple(specialDeclaration, complexStatements: complexStatements))
       }
@@ -422,7 +444,9 @@ extension SemanticAnalyzer {
     return ASTPassResult(element: specialDeclaration, diagnostics: diagnostics, passContext: passContext)
   }
 
-  private func isComplexStatement(_ statement: Statement, env environment: Environment, enclosingType: RawTypeIdentifier) -> Bool {
+  private func isComplexStatement(_ statement: Statement,
+                                  env environment: Environment,
+                                  enclosingType: RawTypeIdentifier) -> Bool {
     switch statement {
     case .expression(let expression):
       switch expression {
@@ -431,40 +455,49 @@ extension SemanticAnalyzer {
           return true
         }
       case .functionCall(let function):
-        let match = environment.matchFunctionCall(function, enclosingType: enclosingType, typeStates: [], callerProtections: [], scopeContext: ScopeContext())
+        let match = environment.matchFunctionCall(function,
+                                                  enclosingType: enclosingType,
+                                                  typeStates: [],
+                                                  callerProtections: [],
+                                                  scopeContext: ScopeContext())
         if case .matchedFunction(let functionInformation) = match,
           !functionInformation.isMutating {
           return false
         }
-        if case .matchedEvent(_) = environment.matchEventCall(function, enclosingType: enclosingType, scopeContext: ScopeContext()) {
+        if case .matchedEvent(_) = environment.matchEventCall(function,
+                                                              enclosingType: enclosingType,
+                                                              scopeContext: ScopeContext()) {
           return false
         }
         return true
-      case .identifier(_), .inoutExpression(_), .literal(_), .arrayLiteral(_),
-           .dictionaryLiteral(_), .self(_), .variableDeclaration(_), .bracketedExpression(_),
-           .subscriptExpression(_),  .range(_):
+      case .identifier, .inoutExpression, .literal, .arrayLiteral,
+           .dictionaryLiteral, .self, .variableDeclaration, .bracketedExpression,
+           .subscriptExpression, .range:
         return false
-      case .rawAssembly(_), .sequence(_):
+      case .rawAssembly, .sequence:
         return true
-      case .attemptExpression(_):
+      case .attemptExpression:
         return true
       }
-    case .ifStatement(_):
+    case .ifStatement:
       return false
-    case .returnStatement(_), .forStatement(_), .becomeStatement(_):
+    case .returnStatement, .forStatement, .becomeStatement:
       return true
-    case .emitStatement(_):
+    case .emitStatement:
       return false
     }
     return true
   }
 
-  public func postProcess(specialDeclaration: SpecialDeclaration, passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
+  public func postProcess(specialDeclaration: SpecialDeclaration,
+                          passContext: ASTPassContext) -> ASTPassResult<SpecialDeclaration> {
     var diagnostics = [Diagnostic]()
     var passContext = passContext
 
     // If we are in a contract behavior declaration, of a contract, check there is only one public initializer.
-    if let context = passContext.contractBehaviorDeclarationContext, passContext.traitDeclarationContext == nil, specialDeclaration.isPublic {
+    if let context = passContext.contractBehaviorDeclarationContext,
+      passContext.traitDeclarationContext == nil,
+      specialDeclaration.isPublic {
       let contractName = context.contractIdentifier.name
 
       // The caller protection block in which this initializer appears should be scoped by "any".
@@ -478,12 +511,15 @@ extension SemanticAnalyzer {
         if let publicFallback = passContext.environment!.publicFallback(forContract: contractName),
           publicFallback.sourceLocation != specialDeclaration.sourceLocation,
           specialDeclaration.isFallback {
-          diagnostics.append(.multiplePublicFallbacksDefined(specialDeclaration, originalFallbackLocation: publicFallback.sourceLocation))
+          diagnostics.append(.multiplePublicFallbacksDefined(specialDeclaration,
+                                                             originalFallbackLocation: publicFallback.sourceLocation))
         } else if let publicInitializer = passContext.environment!.publicInitializer(forContract: contractName),
           publicInitializer.sourceLocation != specialDeclaration.sourceLocation,
           specialDeclaration.isInit {
           // There can be at most one public initializer.
-          diagnostics.append(.multiplePublicInitializersDefined(specialDeclaration, originalInitializerLocation: publicInitializer.sourceLocation))
+          diagnostics.append(
+            .multiplePublicInitializersDefined(specialDeclaration,
+                                               originalInitializerLocation: publicInitializer.sourceLocation))
         } else {
           // This is the first public initializer we encounter in this contract.
           if specialDeclaration.isInit {
@@ -506,12 +542,13 @@ extension SemanticAnalyzer {
       }
     }
 
-
     // Check all the properties in the type have been assigned.
     if specialDeclaration.isInit, let unassignedProperties = passContext.unassignedProperties {
 
       if unassignedProperties.count > 0 {
-        diagnostics.append(.returnFromInitializerWithoutInitializingAllProperties(specialDeclaration, unassignedProperties: unassignedProperties))
+        diagnostics.append(
+          .returnFromInitializerWithoutInitializingAllProperties(specialDeclaration,
+                                                                 unassignedProperties: unassignedProperties))
       }
     }
 
@@ -520,7 +557,6 @@ extension SemanticAnalyzer {
     return ASTPassResult(element: specialDeclaration, diagnostics: diagnostics, passContext: passContext)
   }
 }
-
 
 extension ASTPassContext {
   /// The list of unassigned properties in a type.

--- a/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
+++ b/Sources/SemanticAnalyzer/SemanticAnalyzer.swift
@@ -12,7 +12,8 @@ import Diagnostic
 public struct SemanticAnalyzer: ASTPass {
   public init() {}
 
-  public func postProcess(topLevelModule: TopLevelModule, passContext: ASTPassContext) -> ASTPassResult<TopLevelModule> {
+  public func postProcess(topLevelModule: TopLevelModule,
+                          passContext: ASTPassContext) -> ASTPassResult<TopLevelModule> {
     var diagnostics = [Diagnostic]()
     let environment = passContext.environment!
 
@@ -25,7 +26,8 @@ public struct SemanticAnalyzer: ASTPass {
         if passContext.environment!.publicFallback(forContract: contractDeclaration.identifier.name) == nil {
           let fallbacks = passContext.environment!.fallbacks(in: contractDeclaration.identifier.name)
           if !fallbacks.isEmpty {
-            diagnostics.append(.contractOnlyHasPrivateFallbacks(contractIdentifier: contractDeclaration.identifier, fallbacks.map{$0.declaration}))
+            diagnostics.append(.contractOnlyHasPrivateFallbacks(contractIdentifier: contractDeclaration.identifier,
+                                                                fallbacks.map {$0.declaration}))
           }
         }
         // Check that all trait functions are defined

--- a/Sources/SemanticAnalyzer/SemanticError.swift
+++ b/Sources/SemanticAnalyzer/SemanticError.swift
@@ -14,19 +14,26 @@ import Lexer
 
 extension Diagnostic {
   static func invalidRedeclaration(_ identifier: Identifier, originalSource: Identifier) -> Diagnostic {
-    let note = Diagnostic(severity: .note, sourceLocation: originalSource.sourceLocation, message: "\(originalSource.name) is declared here")
-    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation, message: "Invalid redeclaration of '\(identifier.name)'", notes: [note])
+    let note = Diagnostic(severity: .note, sourceLocation: originalSource.sourceLocation,
+                          message: "\(originalSource.name) is declared here")
+    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation,
+                      message: "Invalid redeclaration of '\(identifier.name)'", notes: [note])
   }
 
   static func invalidCharacter(_ identifier: Identifier, character: Character) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation, message: "Use of invalid character '\(character)' in '\(identifier.name)'")
+    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation,
+                      message: "Use of invalid character '\(character)' in '\(identifier.name)'")
   }
 
   static func invalidAddressLiteral(_ literalToken: Token) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: literalToken.sourceLocation, message: "Address literal should be 42 characters long")
+    return Diagnostic(severity: .error, sourceLocation: literalToken.sourceLocation,
+                      message: "Address literal should be 42 characters long")
   }
 
-  static func noTryForFunctionCall(_ functionCall: FunctionCall, contextCallerProtections: [CallerProtection], stateProtections: [TypeState], candidates: [CallableInformation]) -> Diagnostic {
+  static func noTryForFunctionCall(_ functionCall: FunctionCall,
+                                   contextCallerProtections: [CallerProtection],
+                                   stateProtections: [TypeState],
+                                   candidates: [CallableInformation]) -> Diagnostic {
     let candidateNotes = candidates.map { candidate -> Diagnostic in
       guard case .functionInformation(let functionCandidate) = candidate else {
         fatalError("Non-function CallableInformation where function expected")
@@ -42,18 +49,23 @@ extension Diagnostic {
         messageTail = ", which requires the caller protection '\(callerProtections)'"
       }
 
-      return Diagnostic(severity: .note, sourceLocation: functionCandidate.declaration.sourceLocation, message: "Perhaps you meant this function\(messageTail)")
+      return Diagnostic(severity: .note, sourceLocation: functionCandidate.declaration.sourceLocation,
+                        message: "Perhaps you meant this function\(messageTail)")
     }
 
     let callerPlural = contextCallerProtections.count > 1
     let statesPlural = stateProtections.count > 1
     let statesSpecified = " at \(statesPlural ? "states": "state") '\(renderGroup(stateProtections))'"
-    return Diagnostic(severity: .error, sourceLocation: functionCall.sourceLocation, message: "Function '\(functionCall.identifier.name)' cannot be called using the \(callerPlural ? "protections" : "protection") '\(renderGroup(contextCallerProtections))'\(stateProtections.isEmpty ? "" : statesSpecified)", notes: candidateNotes)
+    return Diagnostic(severity: .error, sourceLocation: functionCall.sourceLocation,
+                      // swiftlint:disable line_length
+                      message: "Function '\(functionCall.identifier.name)' cannot be called using the \(callerPlural ? "protections" : "protection") '\(renderGroup(contextCallerProtections))'\(stateProtections.isEmpty ? "" : statesSpecified)", notes: candidateNotes)
+                      // swiftlint:enable line_length
   }
 
-  static func noMatchingFunctionForFunctionCall(_ functionCall: FunctionCall, candidates: [CallableInformation]) -> Diagnostic {
+  static func noMatchingFunctionForFunctionCall(_ functionCall: FunctionCall,
+                                                candidates: [CallableInformation]) -> Diagnostic {
     let candidateNotes = candidates.map { callablecandidate -> Diagnostic in
-      switch callablecandidate{
+      switch callablecandidate {
       case .functionInformation(let candidate):
         let callerProtections = renderGroup(candidate.callerProtections)
         let messageTail: String
@@ -66,81 +78,137 @@ extension Diagnostic {
           messageTail = ", which requires the caller protection '\(callerProtections)'"
         }
 
-        return Diagnostic(severity: .note, sourceLocation: candidate.declaration.sourceLocation, message: "Perhaps you meant this function\(messageTail)")
+        return Diagnostic(severity: .note, sourceLocation: candidate.declaration.sourceLocation,
+                          message: "Perhaps you meant this function\(messageTail)")
       case .specialInformation(let candidate):
         if candidate.declaration.isInit {
-          return Diagnostic(severity: .note, sourceLocation: candidate.declaration.sourceLocation, message: "Perhaps you meant the initializer for this struct")
+          return Diagnostic(severity: .note, sourceLocation: candidate.declaration.sourceLocation,
+                            message: "Perhaps you meant the initializer for this struct")
         } else {
           // Is fallback
-          return Diagnostic(severity: .note, sourceLocation: candidate.declaration.sourceLocation, message: "Perhaps you meant this fallback function")
+          return Diagnostic(severity: .note, sourceLocation: candidate.declaration.sourceLocation,
+                            message: "Perhaps you meant this fallback function")
         }
       }
     }
 
-    return Diagnostic(severity: .error, sourceLocation: functionCall.sourceLocation, message: "Function '\(functionCall.identifier.name)' is not in scope", notes: candidateNotes)
+    return Diagnostic(severity: .error, sourceLocation: functionCall.sourceLocation,
+                      message: "Function '\(functionCall.identifier.name)' is not in scope", notes: candidateNotes)
   }
 
   static func partialMatchingEvents(_ functionCall: FunctionCall, candidates: [EventInformation]) -> Diagnostic {
     let candidateNotes = candidates.map { candidate -> Diagnostic in
-      return Diagnostic(severity: .note, sourceLocation: candidate.declaration.sourceLocation, message: "Perhaps you meant this event '\(candidate.declaration.identifier.name)(\(candidate.declaration.variableDeclarations.map({ "\($0.identifier.name): \($0.type)" }).joined(separator: ", ")))'")
+      let variableDeclarations = candidate.declaration.variableDeclarations.map {
+        "\($0.identifier.name): \($0.type)"
+      }.joined(separator: ", ")
+
+      let identName = candidate.declaration.identifier.name
+      return Diagnostic(severity: .note,
+                        sourceLocation: candidate.declaration.sourceLocation,
+                        message: "Perhaps you meant this event '\(identName)(\(variableDeclarations))'")
     }
 
-    return Diagnostic(severity: .error, sourceLocation: functionCall.sourceLocation, message: "Event '\(functionCall.identifier.name)' cannot be called using the given parameters", notes: candidateNotes)
+    return Diagnostic(severity: .error,
+                      sourceLocation: functionCall.sourceLocation,
+                      message: "Event '\(functionCall.identifier.name)' cannot be called using the given parameters",
+                      notes: candidateNotes)
   }
 
   static func noMatchingEvents(_ functionCall: FunctionCall) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: functionCall.identifier.sourceLocation, message: "Event '\(functionCall.identifier.name)' is not in scope")
+    return Diagnostic(severity: .error, sourceLocation: functionCall.identifier.sourceLocation,
+                      message: "Event '\(functionCall.identifier.name)' is not in scope")
   }
 
   static func noReceiverForStructInitializer(_ functionCall: FunctionCall) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: functionCall.sourceLocation, message: "Cannot call struct initializer '\(functionCall.identifier.name)' without receiver assignment")
+    return Diagnostic(
+      severity: .error, sourceLocation: functionCall.sourceLocation,
+      message: "Cannot call struct initializer '\(functionCall.identifier.name)' without receiver assignment")
   }
 
-  static func contractBehaviorDeclarationNoMatchingContract(_ contractBehaviorDeclaration: ContractBehaviorDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: contractBehaviorDeclaration.sourceLocation, message: "Contract behavior declaration for '\(contractBehaviorDeclaration.contractIdentifier.name)' has no associated contract declaration")
+  static func contractBehaviorDeclarationNoMatchingContract(
+    _ contractBehaviorDeclaration: ContractBehaviorDeclaration) -> Diagnostic {
+    let identName = contractBehaviorDeclaration.contractIdentifier.name
+    return Diagnostic(
+      severity: .error, sourceLocation: contractBehaviorDeclaration.sourceLocation,
+      message: "Contract behavior declaration for '\(identName)' has no associated contract declaration")
   }
 
-  static func contractBehaviorDeclarationMismatchedStatefulness(_ contractBehaviorDeclaration: ContractBehaviorDeclaration) -> Diagnostic {
+  static func contractBehaviorDeclarationMismatchedStatefulness(
+    _ contractBehaviorDeclaration: ContractBehaviorDeclaration) -> Diagnostic {
     let isContractStateful = contractBehaviorDeclaration.states == []
 
-    return Diagnostic(severity: .error, sourceLocation: contractBehaviorDeclaration.sourceLocation, message: "Contract '\(contractBehaviorDeclaration.contractIdentifier.name)' is \(isContractStateful ? "" : "not ")stateful but behavior declaration is\(!isContractStateful ? "" : " not")")
+    let identName = contractBehaviorDeclaration.contractIdentifier.name
+
+    let message: String
+    if isContractStateful {
+      message = "Contract '\(identName)' is stateful but behavior declaration is not"
+    } else {
+      message = "Contract '\(identName)' is not stateful but behavior declaration is"
+    }
+
+    return Diagnostic(severity: .error, sourceLocation: contractBehaviorDeclaration.sourceLocation, message: message)
   }
 
   static func signatureInContract(at sourceLocation: SourceLocation) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: sourceLocation, message: "Cannot use signatures in contracts, only in traits")
+    return Diagnostic(severity: .error, sourceLocation: sourceLocation,
+                      message: "Cannot use signatures in contracts, only in traits")
   }
 
   static func contractTraitMemberInStructTrait(_ member: TraitMember) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: member.sourceLocation, message: "Use of contract trait member in struct trait")
+    return Diagnostic(severity: .error, sourceLocation: member.sourceLocation,
+                      message: "Use of contract trait member in struct trait")
   }
 
   static func structTraitMemberInContractTrait(_ member: TraitMember) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: member.sourceLocation, message: "Use of struct trait member in contract trait")
+    return Diagnostic(severity: .error, sourceLocation: member.sourceLocation,
+                      message: "Use of struct trait member in contract trait")
   }
 
-  static func undeclaredCallerProtection(_ callerProtection: CallerProtection, contractIdentifier: Identifier) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: callerProtection.sourceLocation, message: "Caller protection '\(callerProtection.name)' is undefined in '\(contractIdentifier.name)' or has incompatible type")
+  static func undeclaredCallerProtection(_ callerProtection: CallerProtection,
+                                         contractIdentifier: Identifier) -> Diagnostic {
+    return Diagnostic(
+      severity: .error, sourceLocation: callerProtection.sourceLocation,
+      message: "Caller protection '\(callerProtection.name)' is undefined " +
+               "in '\(contractIdentifier.name)' or has incompatible type")
   }
 
-  static func useOfMutatingExpressionInNonMutatingFunction(_ expression: Expression, functionDeclaration: FunctionDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Use of mutating statement in a nonmutating function")
+  static func useOfMutatingExpressionInNonMutatingFunction(_ expression: Expression,
+                                                           functionDeclaration: FunctionDeclaration) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation,
+                      message: "Use of mutating statement in a nonmutating function")
   }
 
-  static func payableFunctionDoesNotHavePayableValueParameter(_ functionDeclaration: FunctionDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation, message: "Function '\(functionDeclaration.identifier.name)' is declared @payable but doesn't have an implicit parameter of a currency type")
+  static func payableFunctionDoesNotHavePayableValueParameter(
+    _ functionDeclaration: FunctionDeclaration) -> Diagnostic {
+    return Diagnostic(
+      severity: .error, sourceLocation: functionDeclaration.sourceLocation,
+      message: "Function '\(functionDeclaration.identifier.name)' is declared @payable " +
+               "but doesn't have an implicit parameter of a currency type")
   }
 
   static func payableFunctionHasNonPayableValueParameter(_ functionDeclaration: FunctionDeclaration) -> Diagnostic {
-      return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation, message: "Payable function '\(functionDeclaration.identifier.name)' has an implicit parameter of non-currency type")
+      return Diagnostic(
+        severity: .error, sourceLocation: functionDeclaration.sourceLocation,
+        message: "Payable function '\(functionDeclaration.identifier.name)' " +
+                 "has an implicit parameter of non-currency type")
   }
 
-  static func invalidImplicitParameter(_ functionDeclaration: FunctionDeclaration, _ violatingParameter: Identifier) -> Diagnostic {
-      return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation, message: "Parameter '\(violatingParameter.name)' cannot be marked 'implicit' in function '\(functionDeclaration.identifier.name)'")
+  static func invalidImplicitParameter(_ functionDeclaration: FunctionDeclaration,
+                                       _ violatingParameter: Identifier) -> Diagnostic {
+      return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation,
+                        message: "Parameter '\(violatingParameter.name)' cannot be marked " +
+                                 "'implicit' in function '\(functionDeclaration.identifier.name)'")
   }
 
-  static func useOfDynamicParamaterInFunctionDeclaration(_ functionDeclaration: FunctionDeclaration, dynamicParameters: [Parameter]) -> Diagnostic {
-    let notes = dynamicParameters.map { Diagnostic(severity: .note, sourceLocation: $0.sourceLocation, message: "\($0.identifier.name) cannot be used as a parameter") }
-    return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation, message: "Function '\(functionDeclaration.identifier.name)' cannot have dynamic parameters", notes: notes)
+  static func useOfDynamicParamaterInFunctionDeclaration(_ functionDeclaration: FunctionDeclaration,
+                                                         dynamicParameters: [Parameter]) -> Diagnostic {
+    let notes = dynamicParameters.map {
+      Diagnostic(severity: .note, sourceLocation: $0.sourceLocation,
+                 message: "\($0.identifier.name) cannot be used as a parameter")
+    }
+    return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation,
+                      message: "Function '\(functionDeclaration.identifier.name)' cannot have dynamic parameters",
+                      notes: notes)
   }
 
   static func notImplementedFunctions(_ functions: [FunctionInformation], in decl: ContractDeclaration) -> Diagnostic {
@@ -151,174 +219,257 @@ extension Diagnostic {
     return notImplementedFunctions(functions, in: "Struct \(decl.identifier.name)", at: decl.sourceLocation)
   }
 
-  static func notImplementedFunctions(_ functions: [FunctionInformation], in string: String, at source: SourceLocation) -> Diagnostic {
+  static func notImplementedFunctions(_ functions: [FunctionInformation], in string: String,
+                                      at source: SourceLocation) -> Diagnostic {
     let notes = functions.map { function -> Diagnostic in
       if function.isSignature {
-        return Diagnostic(severity: .note, sourceLocation: function.declaration.sourceLocation, message: "Function signature has not been implemented")
+        return Diagnostic(severity: .note, sourceLocation: function.declaration.sourceLocation,
+                          message: "Function signature has not been implemented")
       }
-      return Diagnostic(severity: .note, sourceLocation: function.declaration.sourceLocation, message: "Is this meant to implement the trait signature?")
+      return Diagnostic(severity: .note, sourceLocation: function.declaration.sourceLocation,
+                        message: "Is this meant to implement the trait signature?")
     }
-    return Diagnostic(severity: .error, sourceLocation: source, message: "\(string) doesn't conform to traits as it doesn't implement the declared functions", notes: notes)
+    return Diagnostic(severity: .error, sourceLocation: source,
+                      message: "\(string) doesn't conform to traits as it doesn't implement the declared functions",
+                      notes: notes)
   }
 
-  static func notImplementedInitialiser(_ intialisers: [SpecialInformation], in string: String, at source: SourceLocation) -> Diagnostic {
-    let notes = intialisers.map { Diagnostic(severity: .note, sourceLocation: $0.declaration.sourceLocation, message: "Initialiser has not been implemented") }
-    return Diagnostic(severity: .error, sourceLocation: source, message: "\(string) doesn't conform to traits as it doesn't implement the declared initialiser", notes: notes)
+  static func notImplementedInitialiser(_ intialisers: [SpecialInformation],
+                                        in string: String, at source: SourceLocation) -> Diagnostic {
+    let notes = intialisers.map {
+      Diagnostic(severity: .note, sourceLocation: $0.declaration.sourceLocation,
+                 message: "Initialiser has not been implemented")
+    }
+
+    return Diagnostic(severity: .error, sourceLocation: source,
+                      message: "\(string) doesn't conform to traits as it doesn't implement the declared initialiser",
+                      notes: notes)
   }
 
-  static func notImplementedInitialiser(_ intialisers: [SpecialInformation], in decl: ContractDeclaration) -> Diagnostic {
+  static func notImplementedInitialiser(_ intialisers: [SpecialInformation],
+                                        in decl: ContractDeclaration) -> Diagnostic {
     return notImplementedInitialiser(intialisers, in: "Contract", at: decl.sourceLocation)
   }
 
-  static func notImplementedInitialiser(_ intialisers: [SpecialInformation], in decl: StructDeclaration) -> Diagnostic {
+  static func notImplementedInitialiser(_ intialisers: [SpecialInformation],
+                                        in decl: StructDeclaration) -> Diagnostic {
     return notImplementedInitialiser(intialisers, in: "Struct", at: decl.sourceLocation)
   }
 
   static func ambiguousPayableValueParameter(_ functionDeclaration: FunctionDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation, message: "Ambiguous implicit payable value parameter. Only one parameter can be declared implicit with a currency type")
+    return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation,
+                      message: "Ambiguous implicit payable value parameter." +
+                               " Only one parameter can be declared implicit with a currency type")
   }
 
   static func useOfUndeclaredIdentifier(_ identifier: Identifier) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation, message: "Use of undeclared identifier '\(identifier.name)'")
+    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation,
+                      message: "Use of undeclared identifier '\(identifier.name)'")
   }
 
   static func useOfUndeclaredType(_ type: Type) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: type.sourceLocation, message: "Use of undeclared type '\(type.name)'")
+    return Diagnostic(severity: .error, sourceLocation: type.sourceLocation,
+                      message: "Use of undeclared type '\(type.name)'")
   }
 
   static func missingReturnInNonVoidFunction(closeBraceToken: Token, resultType: Type) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: closeBraceToken.sourceLocation, message: "Missing return in function expected to return '\(resultType.name)'")
+    return Diagnostic(severity: .error, sourceLocation: closeBraceToken.sourceLocation,
+                      message: "Missing return in function expected to return '\(resultType.name)'")
   }
 
   static func invalidReturnTypeInFunction(_ functionDeclaration: FunctionDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation, message: "Type '\(functionDeclaration.signature.resultType!.name)' not valid as return type in function '\(functionDeclaration.identifier.name)'")
+    return Diagnostic(severity: .error, sourceLocation: functionDeclaration.sourceLocation,
+                      message: "Type '\(functionDeclaration.signature.resultType!.name)' not valid as " +
+                               "return type in function '\(functionDeclaration.identifier.name)'")
   }
 
-  static func reassignmentToConstant(_ identifier: Identifier, _ declarationSourceLocation: SourceLocation) -> Diagnostic {
-    let note = Diagnostic(severity: .note, sourceLocation: declarationSourceLocation, message: "'\(identifier.name)' is declared here")
-    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation, message: "Cannot reassign to value: '\(identifier.name)' is a 'let' constant", notes: [note])
+  static func reassignmentToConstant(_ identifier: Identifier,
+                                     _ declarationSourceLocation: SourceLocation) -> Diagnostic {
+    let note = Diagnostic(severity: .note, sourceLocation: declarationSourceLocation,
+                          message: "'\(identifier.name)' is declared here")
+    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation,
+                      message: "Cannot reassign to value: '\(identifier.name)' is a 'let' constant",
+                      notes: [note])
   }
 
   static func statePropertyIsNotAssignedAValue(_ variableDeclaration: VariableDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation, message: "State property '\(variableDeclaration.identifier.name)' needs to be assigned a value")
+    return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation,
+                      message: "State property '\(variableDeclaration.identifier.name)' needs to be assigned a value")
   }
 
   static func statePropertyUsedWithinPropertyInitializer(_ identifier: Identifier) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation, message: "Cannot use state property '\(identifier.name)' within the initialization of another property")
+    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation,
+                      message: "Cannot use state property '\(identifier.name)' within the " +
+                               "initialization of another property")
   }
 
   static func invalidRangeDeclaration(_ literalExpression: Expression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: literalExpression.sourceLocation, message: "Cannot create ranges of non-numeric literals")
+    return Diagnostic(severity: .error, sourceLocation: literalExpression.sourceLocation,
+                      message: "Cannot create ranges of non-numeric literals")
   }
 
   static func recursiveStruct(_ structIdentifier: Identifier, _ enclosingType: PropertyInformation) -> Diagnostic {
-    let note = Diagnostic(severity: .note, sourceLocation: enclosingType.sourceLocation, message: "State property '\(enclosingType.property.identifier.name)' of type '\(enclosingType.rawType.name)' refers to enclosing type of '\(structIdentifier.name)'")
-    return Diagnostic(severity: .error, sourceLocation: structIdentifier.sourceLocation, message: "Declaration of recursive struct '\(structIdentifier.name)'", notes: [note])
+    let identName = enclosingType.property.identifier.name
+    let note = Diagnostic(severity: .note, sourceLocation: enclosingType.sourceLocation,
+                          message: "State property '\(identName)' of type '\(enclosingType.rawType.name)' refers to " +
+                                   "enclosing type of '\(structIdentifier.name)'")
+    return Diagnostic(severity: .error, sourceLocation: structIdentifier.sourceLocation,
+                      message: "Declaration of recursive struct '\(structIdentifier.name)'",
+                      notes: [note])
   }
 
   // INITALISER ERRORS //
 
-  static func returnFromInitializerWithoutInitializingAllProperties(_ initializerDeclaration: SpecialDeclaration, unassignedProperties: [Property]) -> Diagnostic {
+  static func returnFromInitializerWithoutInitializingAllProperties(_ initializerDeclaration: SpecialDeclaration,
+                                                                    unassignedProperties: [Property]) -> Diagnostic {
     let notes = unassignedProperties.map { property in
-      return Diagnostic(severity: .note, sourceLocation: property.sourceLocation, message: "'\(property.identifier.name)' is uninitialized")
+      return Diagnostic(severity: .note, sourceLocation: property.sourceLocation,
+                        message: "'\(property.identifier.name)' is uninitialized")
     }
 
-    return Diagnostic(severity: .error, sourceLocation: initializerDeclaration.closeBraceToken.sourceLocation, message: "Return from initializer without initializing all properties", notes: notes)
+    return Diagnostic(severity: .error, sourceLocation: initializerDeclaration.closeBraceToken.sourceLocation,
+                      message: "Return from initializer without initializing all properties",
+                      notes: notes)
   }
 
-  static func returnFromInitializerWithoutInitializingState(_ initializerDeclaration: SpecialDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: initializerDeclaration.sourceLocation, message: "Return from initializer without initializing state in stateful contract")
+  static func returnFromInitializerWithoutInitializingState(
+    _ initializerDeclaration: SpecialDeclaration) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: initializerDeclaration.sourceLocation,
+                      message: "Return from initializer without initializing state in stateful contract")
   }
 
   static func contractDoesNotHaveAPublicInitializer(contractIdentifier: Identifier) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: contractIdentifier.sourceLocation, message: "Contract '\(contractIdentifier.name)' needs a public initializer accessible using the protection 'any'")
+    return Diagnostic(severity: .error, sourceLocation: contractIdentifier.sourceLocation,
+                      message: "Contract '\(contractIdentifier.name)' needs a public initializer accessible " +
+                               "using the protection 'any'")
   }
 
   static func repeatedConformance(contractIdentifier: Identifier) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: contractIdentifier.sourceLocation, message: "Contract '\(contractIdentifier.name)' has repeated conformances")
+    return Diagnostic(severity: .error, sourceLocation: contractIdentifier.sourceLocation,
+                      message: "Contract '\(contractIdentifier.name)' has repeated conformances")
   }
 
   static func repeatedConformance(structIdentifier: Identifier) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: structIdentifier.sourceLocation, message: "Struct '\(structIdentifier.name)' has repeated conformances")
+    return Diagnostic(severity: .error, sourceLocation: structIdentifier.sourceLocation,
+                      message: "Struct '\(structIdentifier.name)' has repeated conformances")
   }
 
-  static func traitsAreIncompatible(_ contractDeclaration: ContractDeclaration, _ functions: [FunctionInformation]) -> Diagnostic {
-     return traitsAreIncompatible(in: "Contract '\(contractDeclaration.identifier.name)'", with: functions, at: contractDeclaration.sourceLocation)
+  static func traitsAreIncompatible(_ contractDeclaration: ContractDeclaration,
+                                    _ functions: [FunctionInformation]) -> Diagnostic {
+     return traitsAreIncompatible(in: "Contract '\(contractDeclaration.identifier.name)'",
+      with: functions,
+      at: contractDeclaration.sourceLocation)
   }
 
-  static func traitsAreIncompatible(_ structDeclaration: StructDeclaration, _ functions: [FunctionInformation]) -> Diagnostic {
-    return traitsAreIncompatible(in: "Struct '\(structDeclaration.identifier.name)'", with: functions, at: structDeclaration.sourceLocation)
+  static func traitsAreIncompatible(_ structDeclaration: StructDeclaration,
+                                    _ functions: [FunctionInformation]) -> Diagnostic {
+    return traitsAreIncompatible(in: "Struct '\(structDeclaration.identifier.name)'",
+      with: functions,
+      at: structDeclaration.sourceLocation)
   }
 
-  static func traitsAreIncompatible(in type: String, with functions: [FunctionInformation], at source: SourceLocation) -> Diagnostic {
-    let notes = functions.map{ function in
-      return Diagnostic(severity: .note, sourceLocation: function.declaration.sourceLocation, message: "Function with the name '\(function.declaration.name)' has been declared here")
+  static func traitsAreIncompatible(in type: String,
+                                    with functions: [FunctionInformation],
+                                    at source: SourceLocation) -> Diagnostic {
+    let notes = functions.map { function in
+      return Diagnostic(severity: .note, sourceLocation: function.declaration.sourceLocation,
+                        message: "Function with the name '\(function.declaration.name)' has been declared here")
     }
-    return Diagnostic(severity: .error, sourceLocation: source, message: "\(type) conforms to traits using the same function name", notes: notes)
+    return Diagnostic(severity: .error, sourceLocation: source,
+                      message: "\(type) conforms to traits using the same function name",
+                      notes: notes)
   }
 
   static func contractUsesUndeclaredTraits(_ trait: Conformance, in type: Identifier) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: trait.sourceLocation, message: "Contract '\(type.name)' conforms to undeclared trait '\(trait.identifier.name)'")
+    return Diagnostic(severity: .error, sourceLocation: trait.sourceLocation,
+                      message: "Contract '\(type.name)' conforms to undeclared trait '\(trait.identifier.name)'")
   }
 
-  static func multiplePublicInitializersDefined(_ invalidAdditionalInitializer: SpecialDeclaration, originalInitializerLocation: SourceLocation) -> Diagnostic {
-    let note = Diagnostic(severity: .note, sourceLocation: originalInitializerLocation, message: "A public initializer is already declared here")
-    return Diagnostic(severity: .error, sourceLocation: invalidAdditionalInitializer.sourceLocation, message: "A public initializer has already been defined", notes: [note])
+  static func multiplePublicInitializersDefined(_ invalidAdditionalInitializer: SpecialDeclaration,
+                                                originalInitializerLocation: SourceLocation) -> Diagnostic {
+    let note = Diagnostic(severity: .note, sourceLocation: originalInitializerLocation,
+                          message: "A public initializer is already declared here")
+    return Diagnostic(severity: .error, sourceLocation: invalidAdditionalInitializer.sourceLocation,
+                      message: "A public initializer has already been defined",
+                      notes: [note])
   }
 
-  static func contractInitializerNotDeclaredInAnyCallerProtectionBlock(_ initializerDeclaration: SpecialDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: initializerDeclaration.sourceLocation, message: "Public contract initializer should be callable using caller protection 'any'")
+  static func contractInitializerNotDeclaredInAnyCallerProtectionBlock(
+    _ initializerDeclaration: SpecialDeclaration) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: initializerDeclaration.sourceLocation,
+                      message: "Public contract initializer should be callable using caller protection 'any'")
   }
 
   // FALLBACK ERRORS //
 
-  static func multiplePublicFallbacksDefined(_ invalidAdditionalFallback: SpecialDeclaration, originalFallbackLocation: SourceLocation) -> Diagnostic {
-    let note = Diagnostic(severity: .note, sourceLocation: originalFallbackLocation, message: "A public fallback is already declared here")
-    return Diagnostic(severity: .error, sourceLocation: invalidAdditionalFallback.sourceLocation, message: "A public fallback has already been defined", notes: [note])
+  static func multiplePublicFallbacksDefined(_ invalidAdditionalFallback: SpecialDeclaration,
+                                             originalFallbackLocation: SourceLocation) -> Diagnostic {
+    let note = Diagnostic(severity: .note, sourceLocation: originalFallbackLocation,
+                          message: "A public fallback is already declared here")
+    return Diagnostic(severity: .error, sourceLocation: invalidAdditionalFallback.sourceLocation,
+                      message: "A public fallback has already been defined",
+                      notes: [note])
   }
 
-  static func contractFallbackNotDeclaredInAnyCallerProtectionBlock(_ invalidFallback: SpecialDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: invalidFallback.sourceLocation, message: "Public contract fallback should be callable using caller protection 'any'")
+  static func contractFallbackNotDeclaredInAnyCallerProtectionBlock(
+    _ invalidFallback: SpecialDeclaration) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: invalidFallback.sourceLocation,
+                      message: "Public contract fallback should be callable using caller protection 'any'")
   }
 
   static func fallbackDeclaredWithArguments(_ invalidFallback: SpecialDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: invalidFallback.sourceLocation, message: "Contract fallback shouldn't have any arguments")
+    return Diagnostic(severity: .error, sourceLocation: invalidFallback.sourceLocation,
+                      message: "Contract fallback shouldn't have any arguments")
   }
 
   static func cannotInferHiddenValue(_ identifier: Identifier, _ type: Type) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation, message: "Cannot infer hidden values in case '\(identifier.name)' for hidden type '\(type.name)'")
+    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation,
+                      message: "Cannot infer hidden values in case '\(identifier.name)' for hidden type '\(type.name)'")
   }
 
   static func invalidHiddenValue(_ enumCase: EnumMember) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: enumCase.hiddenValue!.sourceLocation, message: "Invalid hidden value for enum case '\(enumCase.identifier.name)'")
+    return Diagnostic(severity: .error, sourceLocation: enumCase.hiddenValue!.sourceLocation,
+                      message: "Invalid hidden value for enum case '\(enumCase.identifier.name)'")
   }
 
   static func invalidHiddenType(_ enumDeclaration: EnumDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: enumDeclaration.type.sourceLocation, message: "Invalid hidden type '\(enumDeclaration.type.name)' for enum '\(enumDeclaration.identifier.name)'")
+    let identName = enumDeclaration.identifier.name
+    return Diagnostic(severity: .error, sourceLocation: enumDeclaration.type.sourceLocation,
+                      message: "Invalid hidden type '\(enumDeclaration.type.name)' for enum '\(identName)'")
   }
 
   static func invalidReference(_ identifier: Identifier) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation, message: "Cannot reference enum '\(identifier.name)' alone")
+    return Diagnostic(severity: .error, sourceLocation: identifier.sourceLocation,
+                      message: "Cannot reference enum '\(identifier.name)' alone")
   }
 
   static func multipleReturns(_ statement: ReturnStatement) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: statement.sourceLocation, message: "Early returns are not supported yet")
+    return Diagnostic(severity: .error, sourceLocation: statement.sourceLocation,
+                      message: "Early returns are not supported yet")
   }
 
   static func becomeBeforeReturn(_ statement: BecomeStatement) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: statement.sourceLocation, message: "Cannot become before a return")
+    return Diagnostic(severity: .error, sourceLocation: statement.sourceLocation,
+                      message: "Cannot become before a return")
   }
 
   static func mutatingConstant(_ variableDeclaration: VariableDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation, message: "The variable '\(variableDeclaration.identifier.name)' is both declared constant and mutating")
+    let identName = variableDeclaration.identifier.name
+    return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation,
+                      message: "The variable '\(identName)' is both declared constant and mutating")
   }
 
   static func publicLet(_ variableDeclaration: VariableDeclaration) -> Diagnostic {
-   return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation, message: "The variable '\(variableDeclaration.identifier.name)' is declared public (and a setter will be synthesised) but let variables cannot be set")
+    let identName = variableDeclaration.identifier.name
+    return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation,
+                      message: "The variable '\(identName)' is declared public " +
+                               "(and a setter will be synthesised) but let variables cannot be set")
   }
 
   static func publicAndVisible(_ variableDeclaration: VariableDeclaration) -> Diagnostic {
-   return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation, message: "Cannot declare variable '\(variableDeclaration.identifier.name)' both public and visible")
+    let identName = variableDeclaration.identifier.name
+   return Diagnostic(severity: .error, sourceLocation: variableDeclaration.sourceLocation,
+                     message: "Cannot declare variable '\(identName)' both public and visible")
   }
 
   static func renderGroup(_ protections: [CallerProtection]) -> String {
@@ -334,45 +485,64 @@ extension Diagnostic {
 
 extension Diagnostic {
   static func codeAfterReturn(_ statement: Statement) -> Diagnostic {
-    return Diagnostic(severity: .warning, sourceLocation: statement.sourceLocation, message: "Code after return/become will never be executed")
+    return Diagnostic(severity: .warning, sourceLocation: statement.sourceLocation,
+                      message: "Code after return/become will never be executed")
   }
 
   static func multipleBecomes(_ statement: BecomeStatement) -> Diagnostic {
-    return Diagnostic(severity: .warning, sourceLocation: statement.sourceLocation, message: "Only final become will change state")
+    return Diagnostic(severity: .warning, sourceLocation: statement.sourceLocation,
+                      message: "Only final become will change state")
   }
 
   static func emptyRange(_ rangeExpression: AST.RangeExpression) -> Diagnostic {
-    return Diagnostic(severity: .warning, sourceLocation: rangeExpression.sourceLocation, message: "Range is empty therefore content will be skipped")
+    return Diagnostic(severity: .warning, sourceLocation: rangeExpression.sourceLocation,
+                      message: "Range is empty therefore content will be skipped")
   }
 
   static func functionCanBeDeclaredNonMutating(_ mutatingToken: Token) -> Diagnostic {
-    return Diagnostic(severity: .warning, sourceLocation: mutatingToken.sourceLocation, message: "Function does not have to be declared mutating: none of its statements are mutating")
+    return Diagnostic(severity: .warning, sourceLocation: mutatingToken.sourceLocation,
+                      message: "Function does not have to be declared mutating: none of its statements are mutating")
   }
 
   static func contractNotDeclaredInModule() -> Diagnostic {
     return Diagnostic(severity: .warning, sourceLocation: nil, message: "No contract declaration in top level module")
   }
 
-  static func contractOnlyHasPrivateFallbacks(contractIdentifier: Identifier, _ privateFallbacks: [SpecialDeclaration]) -> Diagnostic {
+  static func contractOnlyHasPrivateFallbacks(contractIdentifier: Identifier,
+                                              _ privateFallbacks: [SpecialDeclaration]) -> Diagnostic {
     var notes = [Diagnostic]()
     for fallback in privateFallbacks {
-      notes.append(Diagnostic(severity: .note, sourceLocation: fallback.sourceLocation, message: "A fallback is declared here"))
+      notes.append(Diagnostic(severity: .note, sourceLocation: fallback.sourceLocation,
+                              message: "A fallback is declared here"))
     }
     let reference = privateFallbacks.count == 1 ? "a private fallback" : "private fallbacks"
-    return Diagnostic(severity: .warning, sourceLocation: contractIdentifier.sourceLocation, message: "Contract '\(contractIdentifier.name)' doesn't have a public fallback but does have \(reference)", notes: notes)
+    let identName = contractIdentifier.name
+    return Diagnostic(severity: .warning, sourceLocation: contractIdentifier.sourceLocation,
+                      message: "Contract '\(identName)' doesn't have a public fallback but does have \(reference)",
+                      notes: notes)
   }
 
   static func fallbackShouldBeSimple(_ complex: SpecialDeclaration, complexStatements: [Statement]) -> Diagnostic {
     var notes = [Diagnostic]()
-    complexStatements.forEach({ notes.append(Diagnostic(severity: .note, sourceLocation: $0.sourceLocation, message: "This statement was flagged as 'complex'")) })
-    return Diagnostic(severity: .warning, sourceLocation: complex.sourceLocation, message: "This fallback is likely to use over 2 300 gas which is the limit for calls sending ETH directly", notes: notes)
+    complexStatements.forEach {
+      notes.append(
+        Diagnostic(severity: .note, sourceLocation: $0.sourceLocation,
+                   message: "This statement was flagged as 'complex'"))
+    }
+
+    return Diagnostic(severity: .warning, sourceLocation: complex.sourceLocation,
+                      message: "This fallback is likely to use over 2 300 gas which is the limit " +
+                               "for calls sending ETH directly",
+                      notes: notes)
   }
 
   static func nonVoidAttemptCall(_ attempt: AttemptExpression) -> Diagnostic {
-    return Diagnostic(severity: .warning, sourceLocation: attempt.sourceLocation, message: "Calling a function returning a non-Void value with try? is not supported yet")
+    return Diagnostic(severity: .warning, sourceLocation: attempt.sourceLocation,
+                      message: "Calling a function returning a non-Void value with try? is not supported yet")
   }
 
   static func mutatingVariable(_ variableDeclaration: VariableDeclaration) -> Diagnostic {
-    return Diagnostic(severity: .warning, sourceLocation: variableDeclaration.sourceLocation, message: "Variables are already implicitly mutating")
+    return Diagnostic(severity: .warning, sourceLocation: variableDeclaration.sourceLocation,
+                      message: "Variables are already implicitly mutating")
   }
 }

--- a/Sources/Source/SourceLocation.swift
+++ b/Sources/Source/SourceLocation.swift
@@ -24,11 +24,14 @@ public struct SourceLocation: Comparable, CustomStringConvertible {
     self.isFromStdlib = isFromStdlib
   }
 
-  public static func spanning<S1: SourceEntity, S2: SourceEntity>(_ lowerBoundEntity: S1, to upperBoundEntity: S2) -> SourceLocation {
+  public static func spanning<S1: SourceEntity, S2: SourceEntity>(_ lowerBoundEntity: S1,
+                                                                  to upperBoundEntity: S2) -> SourceLocation {
     let lowerBound = lowerBoundEntity.sourceLocation
     let upperBound = upperBoundEntity.sourceLocation
     guard lowerBound.line == upperBound.line else { return lowerBound }
-    return SourceLocation(line: lowerBound.line, column: lowerBound.column, length: upperBound.column + upperBound.length - lowerBound.column, file: lowerBound.file)
+
+    let length = upperBound.column + upperBound.length - lowerBound.column
+    return SourceLocation(line: lowerBound.line, column: lowerBound.column, length: length, file: lowerBound.file)
   }
 
   // MARK: - CustomStringConvertible

--- a/Sources/TypeChecker/TypeChecker+Expressions.swift
+++ b/Sources/TypeChecker/TypeChecker+Expressions.swift
@@ -9,15 +9,20 @@ import AST
 import Diagnostic
 
 extension TypeChecker {
-  public func process(binaryExpression: BinaryExpression, passContext: ASTPassContext) -> ASTPassResult<BinaryExpression> {
+  public func process(binaryExpression: BinaryExpression,
+                      passContext: ASTPassContext) -> ASTPassResult<BinaryExpression> {
     var diagnostics = [Diagnostic]()
     let environment = passContext.environment!
     var binaryExpression = binaryExpression
 
     // Check operand types match those required by the operators.
     let typeIdentifier = passContext.enclosingTypeIdentifier!
-    let lhsType = environment.type(of: binaryExpression.lhs, enclosingType: typeIdentifier.name, scopeContext: passContext.scopeContext!)
-    let rhsType = environment.type(of: binaryExpression.rhs, enclosingType: typeIdentifier.name, scopeContext: passContext.scopeContext!)
+    let lhsType = environment.type(of: binaryExpression.lhs,
+                                   enclosingType: typeIdentifier.name,
+                                   scopeContext: passContext.scopeContext!)
+    let rhsType = environment.type(of: binaryExpression.rhs,
+                                   enclosingType: typeIdentifier.name,
+                                   scopeContext: passContext.scopeContext!)
 
     switch binaryExpression.opToken {
     case .dot:
@@ -25,28 +30,67 @@ extension TypeChecker {
     case .equal:
       // Both sides must have the same type.
       if ![lhsType, rhsType].contains(.errorType), !lhsType.isCompatible(with: rhsType) {
-        diagnostics.append(.incompatibleAssignment(lhsType: lhsType, rhsType: rhsType, expression: .binaryExpression(binaryExpression)))
+        diagnostics.append(.incompatibleAssignment(lhsType: lhsType,
+                                                   rhsType: rhsType,
+                                                   expression: .binaryExpression(binaryExpression)))
       }
-    case .plus, .overflowingPlus, .minus, .overflowingMinus, .times, .overflowingTimes, .power, .divide, .plusEqual, .minusEqual, .timesEqual, .divideEqual, .openAngledBracket, .closeAngledBracket, .lessThanOrEqual, .greaterThanOrEqual:
+    case .plus, .overflowingPlus, .minus, .overflowingMinus, .times, .overflowingTimes,
+         .power, .divide, .plusEqual, .minusEqual, .timesEqual, .divideEqual,
+         .openAngledBracket, .closeAngledBracket, .lessThanOrEqual, .greaterThanOrEqual:
       // Both sides must have type Int.
-      if ![lhsType, rhsType].contains(.errorType), !lhsType.isCompatible(with: .basicType(.int)) || !rhsType.isCompatible(with: .basicType(.int)) {
-        diagnostics.append(.incompatibleOperandTypes(operatorKind: binaryExpression.opToken, lhsType: lhsType, rhsType: rhsType, expectedTypes: [.basicType(.int)], expression: .binaryExpression(binaryExpression)))
+      if ![lhsType, rhsType].contains(.errorType),
+        !lhsType.isCompatible(with: .basicType(.int)) ||
+          !rhsType.isCompatible(with: .basicType(.int)) {
+        diagnostics.append(
+          .incompatibleOperandTypes(operatorKind: binaryExpression.opToken,
+                                    lhsType: lhsType,
+                                    rhsType: rhsType,
+                                    expectedTypes: [.basicType(.int)],
+                                    expression: .binaryExpression(binaryExpression)))
       }
     case .and, .or:
       // Both sides must have type Bool.
-      if ![lhsType, rhsType].contains(.errorType), !lhsType.isCompatible(with: .basicType(.bool)) || !rhsType.isCompatible(with: .basicType(.bool)) {
-        diagnostics.append(.incompatibleOperandTypes(operatorKind: binaryExpression.opToken, lhsType: lhsType, rhsType: rhsType, expectedTypes: [.basicType(.bool)], expression: .binaryExpression(binaryExpression)))
+      if ![lhsType, rhsType].contains(.errorType),
+        !lhsType.isCompatible(with: .basicType(.bool)) ||
+          !rhsType.isCompatible(with: .basicType(.bool)) {
+        diagnostics.append(
+          .incompatibleOperandTypes(operatorKind: binaryExpression.opToken,
+                                    lhsType: lhsType,
+                                    rhsType: rhsType,
+                                    expectedTypes: [.basicType(.bool)],
+                                    expression: .binaryExpression(binaryExpression)))
       }
     case .doubleEqual, .notEqual:
       // Both sides must have the same type, and one of either Address, Bool, Int or String.
       if ![lhsType, rhsType].contains(.errorType), !lhsType.isCompatible(with: rhsType) {
-        diagnostics.append(.unmatchedOperandTypes(operatorKind: binaryExpression.opToken, lhsType: lhsType, rhsType: rhsType, expression: .binaryExpression(binaryExpression)))
+        diagnostics.append(
+          .unmatchedOperandTypes(operatorKind: binaryExpression.opToken,
+                                 lhsType: lhsType,
+                                 rhsType: rhsType,
+                                 expression: .binaryExpression(binaryExpression)))
       }
-      let acceptedTypes: [RawType] = [.basicType(.address), .basicType(.bool), .basicType(.int), .basicType(.string), .userDefinedType("Enum")]
-      if ![lhsType, rhsType].contains(.errorType), !acceptedTypes.contains(lhsType) && !environment.isEnumDeclared(lhsType.name) {
-        diagnostics.append(.incompatibleOperandTypes(operatorKind: binaryExpression.opToken, lhsType: lhsType, rhsType: rhsType, expectedTypes: acceptedTypes, expression: .binaryExpression(binaryExpression)))
+
+      let acceptedTypes: [RawType] = [
+        .basicType(.address),
+        .basicType(.bool),
+        .basicType(.int),
+        .basicType(.string),
+        .userDefinedType("Enum")
+      ]
+
+      if ![lhsType, rhsType].contains(.errorType),
+        !acceptedTypes.contains(lhsType) &&
+          !environment.isEnumDeclared(lhsType.name) {
+        diagnostics.append(
+          .incompatibleOperandTypes(operatorKind: binaryExpression.opToken,
+                                    lhsType: lhsType,
+                                    rhsType: rhsType,
+                                    expectedTypes: acceptedTypes,
+                                    expression: .binaryExpression(binaryExpression)))
       }
-    case .at, .openBrace, .closeBrace, .openSquareBracket, .closeSquareBracket, .colon, .doubleColon, .openBracket, .closeBracket, .arrow, .leftArrow, .comma, .semicolon, .doubleSlash, .dotdot, .ampersand, .halfOpenRange, .closedRange, .bang, .question:
+    case .at, .openBrace, .closeBrace, .openSquareBracket, .closeSquareBracket, .colon, .doubleColon,
+         .openBracket, .closeBracket, .arrow, .leftArrow, .comma, .semicolon, .doubleSlash, .dotdot, .ampersand,
+         .halfOpenRange, .closedRange, .bang, .question:
       // These are not valid binary operators.
       fatalError()
     }
@@ -59,15 +103,26 @@ extension TypeChecker {
     let environment = passContext.environment!
     let enclosingType = passContext.enclosingTypeIdentifier!.name
 
-    if case .matchedEvent(let eventInformation) = environment.matchEventCall(functionCall, enclosingType: enclosingType, scopeContext: passContext.scopeContext ?? ScopeContext()) {
+    if case .matchedEvent(let eventInformation) =
+      environment.matchEventCall(functionCall,
+                                 enclosingType: enclosingType,
+                                 scopeContext: passContext.scopeContext ?? ScopeContext()) {
 
       // Ensure an event call's arguments match the expected types.
 
       for argument in functionCall.arguments {
-        let argumentType = environment.type(of: argument.expression, enclosingType: enclosingType, scopeContext: passContext.scopeContext!)
-        let expectedType = eventInformation.declaration.variableDeclarations.filter({ $0.identifier.name == argument.identifier?.name }).first?.type.rawType
+        let argumentType = environment.type(of: argument.expression,
+                                            enclosingType: enclosingType,
+                                            scopeContext: passContext.scopeContext!)
+        let expectedType = eventInformation.declaration.variableDeclarations.filter {
+          $0.identifier.name == argument.identifier?.name
+        }.first?.type.rawType
+
         if argumentType != expectedType {
-          diagnostics.append(.incompatibleArgumentType(actualType: argumentType, expectedType: expectedType!, expression: argument.expression))
+          diagnostics.append(
+            .incompatibleArgumentType(actualType: argumentType,
+                                      expectedType: expectedType!,
+                                      expression: argument.expression))
         }
       }
     }
@@ -75,26 +130,34 @@ extension TypeChecker {
     return ASTPassResult(element: functionCall, diagnostics: diagnostics, passContext: passContext)
   }
 
-  public func process(subscriptExpression: SubscriptExpression, passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression> {
+  public func process(subscriptExpression: SubscriptExpression,
+                      passContext: ASTPassContext) -> ASTPassResult<SubscriptExpression> {
     var diagnostics = [Diagnostic]()
     let environment = passContext.environment!
     let typeIdentifier = passContext.enclosingTypeIdentifier!
     let scopeContext = passContext.scopeContext!
 
-    let identifierType = environment.type(of: subscriptExpression.baseExpression, enclosingType: typeIdentifier.name, scopeContext: scopeContext)
+    let identifierType = environment.type(of: subscriptExpression.baseExpression,
+                                          enclosingType: typeIdentifier.name,
+                                          scopeContext: scopeContext)
 
-    let actualType = environment.type(of: subscriptExpression.indexExpression, enclosingType: typeIdentifier.name, scopeContext: scopeContext)
+    let actualType = environment.type(of: subscriptExpression.indexExpression,
+                                      enclosingType: typeIdentifier.name,
+                                      scopeContext: scopeContext)
     var expectedType: RawType = .errorType
 
     switch identifierType {
-    case .arrayType (_), .fixedSizeArrayType(_): expectedType = .basicType(.int)
+    case .arrayType, .fixedSizeArrayType: expectedType = .basicType(.int)
     case .dictionaryType(let keyType, _): expectedType = keyType
     default:
-      diagnostics.append(.incompatibleSubscript(actualType: identifierType, expression: subscriptExpression.baseExpression))
+      diagnostics.append(.incompatibleSubscript(actualType: identifierType,
+                                                expression: subscriptExpression.baseExpression))
     }
 
     if !actualType.isCompatible(with: expectedType), ![actualType, expectedType].contains(.errorType) {
-      diagnostics.append(.incompatibleSubscriptIndex(actualType: actualType, expectedType: expectedType, expression: .subscriptExpression(subscriptExpression)))
+      diagnostics.append(.incompatibleSubscriptIndex(actualType: actualType,
+                                                     expectedType: expectedType,
+                                                     expression: .subscriptExpression(subscriptExpression)))
     }
     return ASTPassResult(element: subscriptExpression, diagnostics: diagnostics, passContext: passContext)
   }

--- a/Sources/TypeChecker/TypeChecker+Statements.swift
+++ b/Sources/TypeChecker/TypeChecker+Statements.swift
@@ -16,13 +16,17 @@ extension TypeChecker {
     let environment = passContext.environment!
 
     if let expression = returnStatement.expression {
-      let actualType = environment.type(of: expression, enclosingType: typeIdentifier.name, scopeContext: passContext.scopeContext!)
+      let actualType = environment.type(of: expression,
+                                        enclosingType: typeIdentifier.name,
+                                        scopeContext: passContext.scopeContext!)
       let expectedType = functionDeclarationContext.declaration.signature.rawType
 
       // Ensure the type of the returned value in a function matches the function's return type.
 
       if actualType != expectedType {
-        diagnostics.append(.incompatibleReturnType(actualType: actualType, expectedType: expectedType, expression: expression))
+        diagnostics.append(.incompatibleReturnType(actualType: actualType,
+                                                   expectedType: expectedType,
+                                                   expression: expression))
       }
     }
 
@@ -49,26 +53,34 @@ extension TypeChecker {
     let typeIdentifier = passContext.enclosingTypeIdentifier!
     let environment = passContext.environment!
 
-    let varType = environment.type(of: .variableDeclaration(forStatement.variable), enclosingType: typeIdentifier.name, scopeContext: passContext.scopeContext!)
-    let iterableType = environment.type(of: forStatement.iterable, enclosingType: typeIdentifier.name, scopeContext: passContext.scopeContext!)
+    let varType = environment.type(of: .variableDeclaration(forStatement.variable),
+                                   enclosingType: typeIdentifier.name,
+                                   scopeContext: passContext.scopeContext!)
+    let iterableType = environment.type(of: forStatement.iterable,
+                                        enclosingType: typeIdentifier.name,
+                                        scopeContext: passContext.scopeContext!)
 
-    let valueType: RawType;
+    let valueType: RawType
     switch iterableType {
     case .arrayType(let v): valueType = v
     case .rangeType(let v): valueType = v
     case .fixedSizeArrayType(let v, _): valueType = v
     case .dictionaryType(_, let v): valueType = v
     default:
-      diagnostics.append(.incompatibleForIterableType(iterableType: iterableType, statement: .forStatement(forStatement)))
+      diagnostics.append(.incompatibleForIterableType(iterableType: iterableType,
+                                                      statement: .forStatement(forStatement)))
       valueType = .errorType
     }
 
     if case .range(_) = forStatement.iterable, valueType != .basicType(.int) {
-      diagnostics.append(.incompatibleForIterableType(iterableType: iterableType, statement: .forStatement(forStatement)))
+      diagnostics.append(.incompatibleForIterableType(iterableType: iterableType,
+                                                      statement: .forStatement(forStatement)))
     }
 
-    if !varType.isCompatible(with: valueType), ![varType, valueType].contains(.errorType){
-      diagnostics.append(.incompatibleForVariableType(varType: varType, valueType: valueType, statement: .forStatement(forStatement)))
+    if !varType.isCompatible(with: valueType), ![varType, valueType].contains(.errorType) {
+      diagnostics.append(.incompatibleForVariableType(varType: varType,
+                                                      valueType: valueType,
+                                                      statement: .forStatement(forStatement)))
     }
 
     return ASTPassResult(element: forStatement, diagnostics: diagnostics, passContext: passContext)

--- a/Sources/TypeChecker/TypeError.swift
+++ b/Sources/TypeChecker/TypeError.swift
@@ -11,49 +11,86 @@ import Lexer
 
 extension Diagnostic {
   static func incompatibleReturnType(actualType: RawType, expectedType: RawType, expression: Expression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Cannot convert expression of type '\(actualType.name)' to expected return type '\(expectedType.name)'")
+    return Diagnostic(
+      severity: .error, sourceLocation: expression.sourceLocation,
+      message: "Cannot convert expression of type '\(actualType.name)' to expected return type '\(expectedType.name)'")
   }
 
   static func invalidState(falseState: Expression, contract: RawTypeIdentifier) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: falseState.sourceLocation, message: "State not defined for contract '\(contract)'")
+    return Diagnostic(severity: .error, sourceLocation: falseState.sourceLocation,
+                      message: "State not defined for contract '\(contract)'")
   }
 
   static func incompatibleForIterableType(iterableType: RawType, statement: Statement) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: statement.sourceLocation, message: "Invalid iterable type '\(iterableType.name)'")
+    return Diagnostic(severity: .error, sourceLocation: statement.sourceLocation,
+                      message: "Invalid iterable type '\(iterableType.name)'")
   }
 
   static func incompatibleForVariableType(varType: RawType, valueType: RawType, statement: Statement) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: statement.sourceLocation, message: "Cannot convert variable of type '\(varType.name)' to expected iterable value type '\(valueType.name)'")
+    return Diagnostic(
+      severity: .error, sourceLocation: statement.sourceLocation,
+      message: "Cannot convert variable of type '\(varType.name)' to expected iterable value type '\(valueType.name)'")
   }
 
   static func incompatibleAssignment(lhsType: RawType, rhsType: RawType, expression: Expression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Incompatible assignment between values of type '\(lhsType.name)' and '\(rhsType.name)'")
+    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation,
+                      message: "Incompatible assignment between values of type '\(lhsType.name)' and '\(rhsType.name)'")
   }
 
-  static func incompatibleOperandTypes(operatorKind: Token.Kind.Punctuation, lhsType: RawType, rhsType: RawType, expectedTypes: [RawType], expression: Expression) -> Diagnostic {
+  static func incompatibleOperandTypes(operatorKind: Token.Kind.Punctuation,
+                                       lhsType: RawType,
+                                       rhsType: RawType,
+                                       expectedTypes: [RawType],
+                                       expression: Expression) -> Diagnostic {
     let notes = expectedTypes.map { expectedType in
-      return Diagnostic(severity: .note, sourceLocation: expression.sourceLocation, message: "Expected operands to be of type \(expectedType.name)")
+      return Diagnostic(severity: .note, sourceLocation: expression.sourceLocation,
+                        message: "Expected operands to be of type \(expectedType.name)")
     }
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Incompatible use of operator '\(operatorKind.rawValue)' on values of types '\(lhsType.name)' and '\(rhsType.name)'", notes: notes)
+
+    return Diagnostic(
+      severity: .error, sourceLocation: expression.sourceLocation,
+      message: "Incompatible use of operator '\(operatorKind.rawValue)' on values " +
+               "of types '\(lhsType.name)' and '\(rhsType.name)'",
+      notes: notes)
   }
 
-  static func unmatchedOperandTypes(operatorKind: Token.Kind.Punctuation, lhsType: RawType, rhsType: RawType, expression: Expression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Incompatible use of operator '\(operatorKind.rawValue)' on values of unmatched types '\(lhsType.name)' and '\(rhsType.name)'")
+  static func unmatchedOperandTypes(operatorKind: Token.Kind.Punctuation,
+                                    lhsType: RawType,
+                                    rhsType: RawType,
+                                    expression: Expression) -> Diagnostic {
+    return Diagnostic(
+      severity: .error, sourceLocation: expression.sourceLocation,
+      message: "Incompatible use of operator '\(operatorKind.rawValue)' on values " +
+                "of unmatched types '\(lhsType.name)' and '\(rhsType.name)'")
   }
 
-  static func incompatibleArgumentType(actualType: RawType, expectedType: RawType, expression: Expression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Cannot convert expression of type '\(actualType.name)' to expected argument type '\(expectedType.name)'")
+  static func incompatibleArgumentType(actualType: RawType,
+                                       expectedType: RawType,
+                                       expression: Expression) -> Diagnostic {
+    return Diagnostic(
+      severity: .error, sourceLocation: expression.sourceLocation,
+      message: "Cannot convert expression of type '\(actualType.name)' to expected " +
+               "argument type '\(expectedType.name)'")
   }
 
-  static func incompatibleCaseValueType(actualType: RawType, expectedType: RawType, expression: Expression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Cannot convert expression of type '\(actualType.name)' to expected hidden type '\(expectedType.name)'")
+  static func incompatibleCaseValueType(actualType: RawType,
+                                        expectedType: RawType,
+                                        expression: Expression) -> Diagnostic {
+    return Diagnostic(
+      severity: .error, sourceLocation: expression.sourceLocation,
+      message: "Cannot convert expression of type '\(actualType.name)' to expected hidden type '\(expectedType.name)'")
   }
 
   static func incompatibleSubscript(actualType: RawType, expression: Expression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Cannot subscript expression of type '\(actualType.name)'")
+    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation,
+                      message: "Cannot subscript expression of type '\(actualType.name)'")
   }
 
-  static func incompatibleSubscriptIndex(actualType: RawType, expectedType: RawType, expression: Expression) -> Diagnostic {
-    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation, message: "Cannot convert expression of type '\(actualType.name)' to expected subscript type '\(expectedType.name)'")
+  static func incompatibleSubscriptIndex(actualType: RawType,
+                                         expectedType: RawType,
+                                         expression: Expression) -> Diagnostic {
+    return Diagnostic(severity: .error, sourceLocation: expression.sourceLocation,
+                      message: "Cannot convert expression of type '\(actualType.name)' to expected " +
+                               "subscript type '\(expectedType.name)'")
   }
 }

--- a/Sources/flintc/SolcCompiler.swift
+++ b/Sources/flintc/SolcCompiler.swift
@@ -13,9 +13,10 @@ struct SolcCompiler {
   var outputDirectory: URL
   var emitBytecode: Bool
 
-  func compile() {
-    let temporaryFile = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(UUID().uuidString)
-    try! inputSource.write(to: temporaryFile, atomically: true, encoding: .utf8)
+  func compile() throws {
+    let temporaryFile = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      .appendingPathComponent(UUID().uuidString)
+    try inputSource.write(to: temporaryFile, atomically: true, encoding: .utf8)
 
     let process = Process()
 
@@ -23,7 +24,18 @@ struct SolcCompiler {
 
     verifySolc(launchPath: process.launchPath!)
     process.standardError = Pipe()
-    process.arguments = ["solc", temporaryFile.path, "--bin"] + (emitBytecode ? ["--opcodes"] : []) + ["-o", outputDirectory.path]
+    process.arguments = Array([
+      [
+        "solc",
+        temporaryFile.path,
+        "--bin"
+      ],
+      emitBytecode ? ["--opcodes"] : [],
+      [
+        "-o",
+        outputDirectory.path
+      ]
+    ].joined())
 
     process.launch()
     process.waitUntilExit()

--- a/Sources/flintc/StandardLibrary.swift
+++ b/Sources/flintc/StandardLibrary.swift
@@ -14,8 +14,10 @@ struct StandardLibrary {
   var url: URL
 
   var files: [URL] {
+    // swiftlint:disable force_try
     return try! FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: [])
       .filter { $0.pathExtension == "flint" }
+    // swiftlint:enable force_try
   }
 
   static var `default`: StandardLibrary {

--- a/Sources/lite/main.swift
+++ b/Sources/lite/main.swift
@@ -14,6 +14,8 @@ import Symbolic
   import Glibc
 #endif
 
+// swiftlint:disable force_try
+
 /// Finds the named executable relative to the location of the `lite`
 /// executable.
 // Thank you Harlan and Robert! (https://github.com/silt-lang/silt/blob/master/Sources/lite/SiltInvocation.swift)
@@ -34,12 +36,15 @@ var fileCheckExecutableLocation: URL {
 }
 
 func runParserTests() -> Bool {
-  let allPassed = try! runLite(substitutions: [("flintc", "\(flintcExecutableLocation.path)"), ("FileCheck", "\"\(fileCheckExecutableLocation.path)\"")],
-                              pathExtensions: ["flint"],
-                              testDirPath: "Tests/ParserTests",
-                              testLinePrefix: "//",
-                              parallelismLevel: .automatic,
-                              successMessage: "Parser tests passed.")
+  let allPassed = try! runLite(substitutions: [
+        ("flintc", "\(flintcExecutableLocation.path)"),
+        ("FileCheck", "\"\(fileCheckExecutableLocation.path)\"")
+    ],
+    pathExtensions: ["flint"],
+    testDirPath: "Tests/ParserTests",
+    testLinePrefix: "//",
+    parallelismLevel: .automatic,
+    successMessage: "Parser tests passed.")
   return allPassed
 }
 
@@ -72,3 +77,5 @@ func run() -> Int32 {
 }
 
 exit(run())
+
+// swiftlint:enable force_try


### PR DESCRIPTION
# Implementation Overview

Since we are working with the Flint compiler for our group project (a group of 6) we figured that it would help to enforce consistent style. A tool that helps to achieve this is `swiftlint`. Swiftlint will cause all builds to fail unless errors are addressed.

This pull request addresses those issues. Primarily the issue in this repository were the obscenely long lines as well as some unhandled exceptions. We have fixed these issues. We also ran swiftlint's autocorrect over the entire codebase to correct other stylistic issues such as not using the empty tuple `()` in place of `Void`, etc. We have also updated the makefile with a new `lint` step.

# Notes

Adds swiftlint as a dependency, as Makefile will now invoke swiftlint.