### PR TITLE
Update manifest to remove flintrocks

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -84,7 +84,7 @@
       },
       {
         "package": "LanguageServerProtocol",
-        "repositoryURL": "https://github.com/flintrocks/swift-lsp.git",
+        "repositoryURL": "https://github.com/flintlang/swift-lsp.git",
         "state": {
           "branch": "master",
           "revision": "8b3b94f19d93b542be81312c62fc2b25fc0c3e58",

--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
     .package(url: "https://github.com/llvm-swift/FileCheck.git", from: "0.0.4"),
     .package(url: "https://github.com/llvm-swift/Symbolic.git", from: "0.0.1"),
     .package(url: "https://github.com/theguild/json-swift.git", from: "4.0.0"),
-    .package(url: "https://github.com/flintrocks/swift-lsp.git", .branch("master")),
-    .package(url: "https://github.com/flintrocks/Cuckoo.git", .branch("master")),
+    .package(url: "https://github.com/flintlang/swift-lsp.git", .branch("master")),
+    .package(url: "https://github.com/flintlang/Cuckoo.git", .branch("master")),
   ],
   targets: [
     // MARK: Source -


### PR DESCRIPTION
# Implementation Overview

Updates the project manifest to use the flintlang version of the dependencies. GitHub redirects these anyway so this is more of a cosmetic/futureproofing change.

I've also updated the resolution cache file, however `swift package resolve` still resolves Cuckoo to the flintrocks version despite the manifest change. I'm not sure why this is the case but this does not affect functionality.