### PR TITLE
[WIP] Re-entrancy protection

### DIFF
--- a/Sources/IRGen/IRContract.swift
+++ b/Sources/IRGen/IRContract.swift
@@ -11,6 +11,7 @@ import AST
 struct IRContract {
 
   static var stateVariablePrefix = "flintState$"
+  static var reentrancyProtectorValue = 10000
 
   var contractDeclaration: ContractDeclaration
   var contractBehaviorDeclarations: [ContractBehaviorDeclaration]


### PR DESCRIPTION
# Re-entrancy protection for all external calls

## Implementation Overview

This PR adds a re-entrancy protection to all external calls. This is implemented via changing the typestate of the Flint contract to a reserved value before the `call` instructions, then restoring the typestate back immediately after. In the function selector (i.e. whenever a Flint function is called from outside), if the typestate matches the reserved value, `revert` is immediately invoked.

## TODO

 - [ ] add truffle tests – this works as expected in Remix, but it is not very easy to test in truffle, since the `revert` in the Flint call will return control flow to a Solidity contract; probably best to maintain some sort of call counter?
 - [ ] add the `reentrant` hyper-parameter to allow re-entrancy if needed
 - [ ] make sure this is properly documented in the language guide

## Example Flint code

```swift
contract X {
  var accounts: [Address: Int] = [:]
}
external contract trait Account {
  @payable func receiveMoney()
}
X :: targetAccount <- (any) {
  // (other, irrelevant functions)
  public func withdrawMoney() {
    let account: Account = Account(address: targetAccount)
    call(value: Wei(fromUnsafeRaw: self.accounts[targetAccount]))! account.receiveMoney()
    self.accounts[targetAccount] = 0
  }
}
```

Typically code like the snippet above would be vulnerable to re-entrancy attacks, since `Account.receiveMoney` could call `X.withdrawMoney` again, receiving money multiple times. This is possible because the balance is only updated after the call is completed.

With the re-entrancy protection such an attack will be prevented, because the second call to `X.withdrawMoney` (from within `Account.receiveMoney`) will `revert` immediately.