### PR TITLE
Fix dependancy documentation and stdlib path location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,19 @@ git clone --recurse-submodules https://github.com/flintlang/flint
 Or if you cloned normally, make sure to
 ```bash
 git submodules init
-git submodules update
+git submodules update --recursive
 ```
 
-Make sure you have Mono installed
+## Building the compiler
+
+You will need to install [Mono](https://www.mono-project.com/), [Node](https://nodejs.org/en/) and [Swift](https://swift.org/).
+
+Once the dependancies have been installed, run
+```bash
+make
+```
+
+The flint compiler will be outputted to the .build/ directory.
 
 ## Future plans
 

--- a/Sources/Compiler/StandardLibrary.swift
+++ b/Sources/Compiler/StandardLibrary.swift
@@ -26,7 +26,7 @@ public struct StandardLibrary {
     }
 
     //let url = path.deletingLastPathComponent().appendingPathComponent("stdlib")
-    let url = URL(string: "/Users/Zubair/Documents/Imperial/Thesis/Code/flint/stdlib")!
+    let url = URL(string: "stdlib")!
     guard FileManager.default.fileExists(atPath: url.path) else {
       fatalError("Unable to find stdlib.")
     }

--- a/Tests/VerifierTests/run_verifier_tests.py
+++ b/Tests/VerifierTests/run_verifier_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Locate flint contracts
 # Parse contracts


### PR DESCRIPTION
## Notes
- Update README with installation documentation.
- Fix absolute file path to standard library, which was causing a runtime error.
- Update run_verifier_tests.py to run with Python3.