### PR TITLE
Ordered fields and mutable global borrowing

### DIFF
--- a/Sources/MoveGen/AST/FunctionDeclaration.swift
+++ b/Sources/MoveGen/AST/FunctionDeclaration.swift
@@ -48,7 +48,7 @@ extension AST.FunctionDeclaration {
                                           op: Token(kind: .punctuation(.equal),
                                                     sourceLocation: self.sourceLocation),
                                           rhs: .rawAssembly(
-                                            "borrow_global<T>(move(\(firstParameter.identifier.name.mangled)))",
+                                            "borrow_global_mut<T>(move(\(firstParameter.identifier.name.mangled)))",
                                             resultType: selfParameter.type.rawType))
     wrapperFunctionDeclaration.body.append(.expression(.binaryExpression(selfAssignment)))
 

--- a/Sources/MoveGen/Component/MoveAssignment.swift
+++ b/Sources/MoveGen/Component/MoveAssignment.swift
@@ -2,7 +2,6 @@
 //  MoveAssignment.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 import AST
 import MoveIR

--- a/Sources/MoveGen/Component/MoveIdentifier.swift
+++ b/Sources/MoveGen/Component/MoveIdentifier.swift
@@ -2,7 +2,6 @@
 //  MoveIdentifier.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 import AST
 import Lexer

--- a/Sources/MoveGen/Component/MoveLiteralToken.swift
+++ b/Sources/MoveGen/Component/MoveLiteralToken.swift
@@ -2,7 +2,6 @@
 //  MoveLiteralToken.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 import Lexer
 import MoveIR

--- a/Sources/MoveGen/Component/MoveSelf.swift
+++ b/Sources/MoveGen/Component/MoveSelf.swift
@@ -2,7 +2,6 @@
 //  MoveSelf.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 
 import Foundation

--- a/Sources/MoveGen/Conformance/TraitResolver.swift
+++ b/Sources/MoveGen/Conformance/TraitResolver.swift
@@ -2,7 +2,6 @@
 //  TraitResolver.swift
 //  MoveGen
 //
-//  Created by Niklas Vangerow on 20/10/2018.
 //
 
 import AST

--- a/Sources/MoveGen/Declaration/MoveVariableDeclaration.swift
+++ b/Sources/MoveGen/Declaration/MoveVariableDeclaration.swift
@@ -2,7 +2,6 @@
 //  MoveVariableDeclaration.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 
 import Foundation

--- a/Sources/MoveGen/Expression/MoveAttemptExpression.swift
+++ b/Sources/MoveGen/Expression/MoveAttemptExpression.swift
@@ -2,7 +2,6 @@
 //  MoveAttemptExpression.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 import AST
 import MoveIR

--- a/Sources/MoveGen/Expression/MoveBinaryExpression.swift
+++ b/Sources/MoveGen/Expression/MoveBinaryExpression.swift
@@ -2,7 +2,6 @@
 //  MoveBinaryExpression.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 import AST
 import MoveIR

--- a/Sources/MoveGen/Expression/MoveEventCall.swift
+++ b/Sources/MoveGen/Expression/MoveEventCall.swift
@@ -2,7 +2,6 @@
 //  MoveEventCall.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 import AST
 import MoveIR

--- a/Sources/MoveGen/Expression/MoveExpression.swift
+++ b/Sources/MoveGen/Expression/MoveExpression.swift
@@ -2,7 +2,6 @@
 //  MoveExpression.swift
 //  MoveGen
 //
-//  Created by Franklin Schrans on 27/04/2018.
 //
 
 import AST

--- a/Sources/MoveGen/Expression/MoveFunctionCall.swift
+++ b/Sources/MoveGen/Expression/MoveFunctionCall.swift
@@ -2,7 +2,6 @@
 //  MoveFunctionCall.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 import AST
 import MoveIR

--- a/Sources/MoveGen/Expression/MoveInOutExpression.swift
+++ b/Sources/MoveGen/Expression/MoveInOutExpression.swift
@@ -2,7 +2,6 @@
 //  MoveInOutExpression.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 
 import AST

--- a/Sources/MoveGen/Expression/MoveSubscriptExpression.swift
+++ b/Sources/MoveGen/Expression/MoveSubscriptExpression.swift
@@ -2,7 +2,6 @@
 //  MoveSubscriptExpression.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 import AST
 import MoveIR

--- a/Sources/MoveGen/Expression/MoveTypeConversionExpression.swift
+++ b/Sources/MoveGen/Expression/MoveTypeConversionExpression.swift
@@ -2,7 +2,6 @@
 //  MoveTypeConversionExpression.swift
 //  MoveGen
 //
-//  Created by Nik on 27/11/2018.
 //
 
 import AST

--- a/Sources/MoveGen/Function/FunctionContext.swift
+++ b/Sources/MoveGen/Function/FunctionContext.swift
@@ -2,7 +2,6 @@
 //  Context.swift
 //  MoveGen
 //
-//  Created by Franklin Schrans on 27/04/2018.
 //
 
 import MoveIR

--- a/Sources/MoveGen/Function/MoveContractInitializer.swift
+++ b/Sources/MoveGen/Function/MoveContractInitializer.swift
@@ -189,9 +189,9 @@ struct MoveInitializerBody {
 
     let constructor = Expression.structConstructor(MoveIR.StructConstructor(
         "T",
-        Dictionary(uniqueKeysWithValues: properties.map {
+        properties.map {
           ($0.identifier.name, .transfer(.move(.identifier(MoveSelf.prefix + $0.identifier.name))))
-        })
+        }
     ))
 
     guard !statements.isEmpty else {

--- a/Sources/MoveGen/Function/MoveContractInitializer.swift
+++ b/Sources/MoveGen/Function/MoveContractInitializer.swift
@@ -2,7 +2,6 @@
 //  IULIAInitializer.swift
 //  MoveGen
 //
-//  Created by Franklin Schrans on 4/27/18.
 //
 
 import AST

--- a/Sources/MoveGen/Function/MoveFallback.swift
+++ b/Sources/MoveGen/Function/MoveFallback.swift
@@ -2,7 +2,6 @@
 //  MoveFallback.swift
 //  AST
 //
-//  Created by Hails, Daniel J R on 10/08/2018.
 //
 
 import AST

--- a/Sources/MoveGen/Function/MoveFunction.swift
+++ b/Sources/MoveGen/Function/MoveFunction.swift
@@ -2,7 +2,6 @@
 //  MoveFunction.swift
 //  MoveGen
 //
-//  Created by Franklin Schrans on 12/28/17.
 //
 
 import AST

--- a/Sources/MoveGen/Function/MoveStatement.swift
+++ b/Sources/MoveGen/Function/MoveStatement.swift
@@ -2,7 +2,6 @@
 //  MoveStatement.swift
 //  MoveGen
 //
-//  Created by Franklin Schrans on 27/04/2018.
 //
 
 import AST

--- a/Sources/MoveGen/Function/MoveStructInitializer.swift
+++ b/Sources/MoveGen/Function/MoveStructInitializer.swift
@@ -183,9 +183,9 @@ struct MoveStructInitializerBody {
 
     let constructor = Expression.structConstructor(StructConstructor(
         typeIdentifier.name,
-        Dictionary(uniqueKeysWithValues: properties.map {
+        properties.map {
           ($0.identifier.name, .transfer(.move(.identifier(MoveSelf.prefix + $0.identifier.name))))
-        })
+        }
     ))
 
     guard !statements.isEmpty else {

--- a/Sources/MoveGen/FunctionCallCompletion/FunctionCallCompleter.swift
+++ b/Sources/MoveGen/FunctionCallCompletion/FunctionCallCompleter.swift
@@ -2,7 +2,6 @@
 //  FunctionCallCompleter.swift
 //  MoveGen
 //
-//  Created by Calin Farcas on 26/10/2018.
 //
 
 import AST

--- a/Sources/MoveGen/Mangler.swift
+++ b/Sources/MoveGen/Mangler.swift
@@ -2,7 +2,6 @@
 //  Mangler.swift
 //  AST
 //
-//  Created by Franklin Schrans on 09/02/2018.
 //
 
 import AST

--- a/Sources/MoveGen/MoveContract.swift
+++ b/Sources/MoveGen/MoveContract.swift
@@ -2,7 +2,6 @@
 //  MoveContract.swift
 //  MoveGen
 //
-//  Created by Franklin Schrans on 12/28/17.
 //
 
 import AST

--- a/Sources/MoveGen/Preprocessor/MovePreprocessor+Expressions.swift
+++ b/Sources/MoveGen/Preprocessor/MovePreprocessor+Expressions.swift
@@ -2,7 +2,6 @@
 //  MovePreprocessor+Expressions.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel J R on 21/08/2018.
 //
 
 import AST

--- a/Sources/MoveGen/Preprocessor/MovePreprocessor.swift
+++ b/Sources/MoveGen/Preprocessor/MovePreprocessor.swift
@@ -2,7 +2,6 @@
 //  MovePreprocessor.swift
 //  MoveGen
 //
-//  Created by Franklin Schrans on 2/1/18.
 //
 
 import AST

--- a/Sources/MoveGen/Property/MovePropertyAccess.swift
+++ b/Sources/MoveGen/Property/MovePropertyAccess.swift
@@ -2,7 +2,6 @@
 //  MovePropertyAccess.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 29/08/2018.
 //
 import AST
 import MoveIR

--- a/Sources/MoveGen/Runtime/MoveRuntimeType.swift
+++ b/Sources/MoveGen/Runtime/MoveRuntimeType.swift
@@ -7,7 +7,7 @@
 
 import MoveIR
 
-/// The runtime functions used by Flint.
+/// The runtime Move types used by Flint.
 enum MoveRuntimeType {
   static let imports: [Statement] = []
   static let importsWithStdlib: [Statement] = [.import(ModuleImport(name: "LibraCoin", address: "0x0"))]

--- a/Sources/MoveGen/Runtime/MoveWrapperFunction.swift
+++ b/Sources/MoveGen/Runtime/MoveWrapperFunction.swift
@@ -2,7 +2,6 @@
 //  MoveWrapperFunction.swift
 //  MoveGen
 //
-//  Created by Hails, Daniel R on 19/07/2018.
 //
 
 import AST

--- a/Sources/MoveIR/Assignment.swift
+++ b/Sources/MoveIR/Assignment.swift
@@ -2,7 +2,6 @@
 //  Assignment.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public struct Assignment: CustomStringConvertible, Throwing {

--- a/Sources/MoveIR/Block.swift
+++ b/Sources/MoveIR/Block.swift
@@ -2,7 +2,6 @@
 //  Block.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 import Utils

--- a/Sources/MoveIR/Expression.swift
+++ b/Sources/MoveIR/Expression.swift
@@ -2,7 +2,6 @@
 //  Expression.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public indirect enum Expression: CustomStringConvertible, Throwing {

--- a/Sources/MoveIR/ForLoop.swift
+++ b/Sources/MoveIR/ForLoop.swift
@@ -2,7 +2,6 @@
 //  ForLoop.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public struct ForLoop: CustomStringConvertible {

--- a/Sources/MoveIR/FunctionCall.swift
+++ b/Sources/MoveIR/FunctionCall.swift
@@ -2,7 +2,6 @@
 //  FunctionCall.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public struct FunctionCall: CustomStringConvertible, Throwing {

--- a/Sources/MoveIR/FunctionDefinition.swift
+++ b/Sources/MoveIR/FunctionDefinition.swift
@@ -2,7 +2,6 @@
 //  FunctionDefinition.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public struct FunctionDefinition: CustomStringConvertible {

--- a/Sources/MoveIR/Identifier.swift
+++ b/Sources/MoveIR/Identifier.swift
@@ -2,7 +2,6 @@
 //  Identifier.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public typealias Identifier = String

--- a/Sources/MoveIR/If.swift
+++ b/Sources/MoveIR/If.swift
@@ -2,7 +2,6 @@
 //  If.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 // swiftlint:disable type_name

--- a/Sources/MoveIR/Literal.swift
+++ b/Sources/MoveIR/Literal.swift
@@ -2,7 +2,6 @@
 //  Literal.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public enum Literal: CustomStringConvertible {

--- a/Sources/MoveIR/Statement.swift
+++ b/Sources/MoveIR/Statement.swift
@@ -2,7 +2,6 @@
 //  Statement.swift
 //  MoveIR
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public enum Statement: CustomStringConvertible, Throwing {

--- a/Sources/MoveIR/StructConstructor.swift
+++ b/Sources/MoveIR/StructConstructor.swift
@@ -6,9 +6,9 @@ import Foundation
 
 public struct StructConstructor: CustomStringConvertible, Throwing {
   public let name: Identifier
-  public let fields: [Identifier: Expression]
+  public let fields: [(Identifier, Expression)]
 
-  public init(_ name: Identifier, _ fields: [Identifier: Expression]) {
+  public init(_ name: Identifier, _ fields: [(Identifier, Expression)]) {
     self.name = name
     self.fields = fields
   }

--- a/Sources/MoveIR/Switch.swift
+++ b/Sources/MoveIR/Switch.swift
@@ -2,7 +2,6 @@
 //  Switch.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public struct Switch: CustomStringConvertible, Throwing {

--- a/Sources/MoveIR/Throwing.swift
+++ b/Sources/MoveIR/Throwing.swift
@@ -2,7 +2,6 @@
 //  Throwing.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public protocol Throwing {

--- a/Sources/MoveIR/Type.swift
+++ b/Sources/MoveIR/Type.swift
@@ -2,7 +2,6 @@
 //  Type.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public indirect enum Type: CustomStringConvertible {

--- a/Sources/MoveIR/VariableDeclaration.swift
+++ b/Sources/MoveIR/VariableDeclaration.swift
@@ -2,7 +2,6 @@
 //  VariableDeclaration.swift
 //  YUL
 //
-//  Created by Aurel Bílý on 12/26/18.
 //
 
 public struct VariableDeclaration: CustomStringConvertible, Throwing {

--- a/Tests/MoveTests/BehaviourTests/run_behaviour_tests.py
+++ b/Tests/MoveTests/BehaviourTests/run_behaviour_tests.py
@@ -18,7 +18,7 @@ class MoveRuntimeError(RuntimeError):
 
     @classmethod
     def from_output(cls, output):
-        line = re.search(r"Aborted\((\d+)\)", output)
+        line = re.search(r"sub_status: Some\((\d+)\)", output)
         if line:
             line = int(line.group(1))
         return cls(output, line)

--- a/Tests/MoveTests/BehaviourTests/tests/callerprotections-counter.flint
+++ b/Tests/MoveTests/BehaviourTests/tests/callerprotections-counter.flint
@@ -1,3 +1,5 @@
+//! disable stdlib
+
 contract Counter {
   visible var count: Int = 0
   visible var owner: Address = 0x1000000000000000000000000000000000000000

--- a/Tests/MoveTests/BehaviourTests/tests/callerprotections-counter.mvir
+++ b/Tests/MoveTests/BehaviourTests/tests/callerprotections-counter.mvir
@@ -19,6 +19,6 @@ main () {
   assert(Counter.getCount(copy(this)) == 1, 4);
   assert(Counter.getFriend(copy(this)) == copy(this), 4001);
   assert(Counter.getOwner(copy(this)) == 0x1000000000000000000000000000000000000000, 4002);
-  Counter.increment(copy(this));  //! expect fail 14
+  Counter.increment(copy(this));  //! expect fail 16
   return;
 }

--- a/Tests/MoveTests/BehaviourTests/tests/defaultparams.flint
+++ b/Tests/MoveTests/BehaviourTests/tests/defaultparams.flint
@@ -1,3 +1,5 @@
+//! disable stdlib
+
 contract Test {
   var a: Int
   var b: Int

--- a/Tests/MoveTests/BehaviourTests/tests/enums.flint
+++ b/Tests/MoveTests/BehaviourTests/tests/enums.flint
@@ -1,3 +1,5 @@
+//! disable stdlib
+
 enum A: Int {
   case a = 1
   case b

--- a/Tests/MoveTests/BehaviourTests/tests/externaltraits-counter.flint
+++ b/Tests/MoveTests/BehaviourTests/tests/externaltraits-counter.flint
@@ -1,3 +1,5 @@
+//! disable stdlib
+
 @module(address: 0x00) // 0x00 is replaced by `Transaction.` by the testsuite
 external trait BaseCounter {
   public func add(n: uint64)

--- a/Tests/MoveTests/BehaviourTests/tests/externaltraits-counter.mvir
+++ b/Tests/MoveTests/BehaviourTests/tests/externaltraits-counter.mvir
@@ -32,7 +32,7 @@ module BaseCounter {
   public add(this_address: address, n: u64) acquires T {
     let this: &mut Self.T;
     let newValue: u64;
-    this = borrow_global<T>(move(this_address));
+    this = borrow_global_mut<T>(move(this_address));
     newValue = *&copy(this).value + move(n);
     *&mut copy(this).value = move(newValue);
     _ = move(this);
@@ -41,7 +41,7 @@ module BaseCounter {
 
   public count(this_address: address): u64 acquires T {
     let this: &mut Self.T;
-    this = borrow_global<T>(move(this_address));
+    this = borrow_global_mut<T>(move(this_address));
     return *&move(this).value;
   }
 }

--- a/Tests/MoveTests/BehaviourTests/tests/inits.flint
+++ b/Tests/MoveTests/BehaviourTests/tests/inits.flint
@@ -1,3 +1,5 @@
+//! disable stdlib
+
 contract Inits {
   var a: Int
   var b: Address

--- a/Tests/MoveTests/BehaviourTests/tests/shapes.flint
+++ b/Tests/MoveTests/BehaviourTests/tests/shapes.flint
@@ -1,3 +1,5 @@
+//! disable stdlib
+
 struct Rectangle {
   public var width: Int
   public var height: Int


### PR DESCRIPTION
### Changes

 - Data constructors in MoveIR now order fields as per definition _[Move compatibility update]_ ba19782 @mrRachar 
 - `borrow_global` has become `borrow_global_mut` _[Move compatibility update]_ c53cecd @mrRachar
 - Updated error line detection as per change to Move's functional testsuite f344b2a @mrRachar 