### PR TITLE
Freezing Swift Package Manager's version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,8 @@ let package = Package(
     ),
   ],
   dependencies: [
+    .package(url: "https://github.com/apple/swift-package-manager",
+             .exact(Version(0, 4, 0))),
     .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", 
              .revision("5d114736f5a98caa8a0ca1c254526f1ce5688f91")),
     .package(url: "https://github.com/onevcat/Rainbow.git", 

--- a/docs/language_guide.md
+++ b/docs/language_guide.md
@@ -157,7 +157,6 @@ git clone --recurse-submodules https://www.github.com/flintlang/flint.git $HOME/
 cd $HOME/.flint
 make release
 echo "export PATH=$HOME/.flint/.build/release/:$PATH" >> ~/.bashrc
-echo "export PATH=$HOME/.flint/.build/release/:$PATH" >> ~/.bashrc
 source ~/.bashrc
 ```
 
@@ -179,11 +178,17 @@ To use Flint in  a [Docker](https://www.docker.com/) container run the following
 ```bash
 git clone --recurse-submodule https://github.com/flintlang/flint.git
 cd flint
-sudo docker build --no-cache -t "flint_docker" .
+sudo docker build -t "flint_docker" 
 ### ---------------------------------------------- ###
 # Docker will build, this process may take some time #
 ### ---------------------------------------------- ###
 sudo docker run --privileged -i -t flint_docker
+```
+
+If it fails, try adding `--no-cache` to the command
+
+```
+sudo docker build --no-cache -t "flint_docker" 
 ```
 
 ### Binary packages


### PR DESCRIPTION
When using the package manager to freeze the versions of Flint's dependencies, the version of the package manager itself was not accounted for, causing the build to fail due to an update of SwiftPM. This is no longer the case 4119418 @matteobilardi.

The unnecessary `--no-cache` option is also removed from the docker installation instructions 2c1c8d8 @mrRachar.