### PR TITLE
General build process fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - "swiftenv install 5.0.2 || true"
     - "swiftenv install 4.2 || true"
     - git clone --branch 0.38.1 https://github.com/realm/SwiftLint.git /tmp/swiftlint
-    - (cd /tmp/swiftlint; swiftenv install; swift build -c release --static-swift-stdlib)
+    - (cd /tmp/swiftlint; swiftenv install; swift build -c release)
     - export PATH="/tmp/swiftlint/.build/x86_64-unknown-linux/release:$PATH"
     script:
     - cd $HOME/.flint

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
     - echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
     - sudo add-apt-repository -y ppa:ethereum/ethereum
-    - curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
+    - curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
     - sudo apt-get update
     - sudo apt-get install -y solc nodejs mono-complete clang z3
     - test -f /usr/bin/msbuild && echo "msbuild exists"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
     - make
     - make release
     - make test
+  - os: osx
+    language: objective-c
+    osx_image: xcode11.3
+    if: tag =~ ^*-macos$
 before_deploy:
 - swift package update
 - make release

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - eval "$(curl -sLk https://swiftenv.fuller.li/install.sh)" 
     - "swiftenv install 5.0.2 || true"
     - "swiftenv install 4.2 || true"
-    - git clone https://github.com/realm/SwiftLint.git /tmp/swiftlint
+    - git clone --branch 0.38.1 https://github.com/realm/SwiftLint.git /tmp/swiftlint
     - (cd /tmp/swiftlint; swiftenv install; swift build -c release --static-swift-stdlib)
     - export PATH="/tmp/swiftlint/.build/x86_64-unknown-linux/release:$PATH"
     script:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ Z3=z3/build/z3
 Boogie_Z3_slink=boogie/Binaries/z3.exe
 Symbooglix_Z3_slink=symbooglix/src/SymbooglixDriver/bin/Release/z3.exe
 Z3_SYSTEM_PATH = $(shell which z3)
-RELEASE_EXECUTABLES=flintc flint-test flint-repl flint-ca flint-lsp
+ZIP_EXECUTABLES ?= flintc flint-test flint-repl flint-ca flint-lsp
 .PHONY: all debug release zip test lint generate-sources generate-mocks test-nogen clean
 
 all: generate-sources $(BOOGIE_EXE) $(SYMBOOGLIX_EXE) debug
@@ -25,11 +25,11 @@ run:
 	swift run dev_version
 
 zip: release
-	for EXECUTABLE in $(RELEASE_EXECUTABLES); do \
+	for EXECUTABLE in $(ZIP_EXECUTABLES); do \
 		cp .build/release/$$EXECUTABLE $$EXECUTABLE; \
 	done
-	zip -r flintc.zip $(RELEASE_EXECUTABLES) stdlib
-	rm $(RELEASE_EXECUTABLES)
+	zip -r flintc.zip $(ZIP_EXECUTABLES) stdlib
+	rm $(ZIP_EXECUTABLES)
 
 test: lint generate-mocks release
 	sed -i -e "s/ as / as! /g" .build/checkouts/Cuckoo/Source/Initialization/ThreadLocal.swift

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ Z3=z3/build/z3
 Boogie_Z3_slink=boogie/Binaries/z3.exe
 Symbooglix_Z3_slink=symbooglix/src/SymbooglixDriver/bin/Release/z3.exe
 Z3_SYSTEM_PATH = $(shell which z3)
+RELEASE_EXECUTABLES=flintc flint-test flint-repl flint-ca flint-lsp
 .PHONY: all debug release zip test lint generate-sources generate-mocks test-nogen clean
 
 all: generate-sources $(BOOGIE_EXE) $(SYMBOOGLIX_EXE) debug
@@ -24,9 +25,11 @@ run:
 	swift run dev_version
 
 zip: release
-	cp .build/release/flintc flintc
-	zip -r flintc.zip flintc stdlib
-	rm flintc
+	for EXECUTABLE in $(RELEASE_EXECUTABLES); do \
+		cp .build/release/$$EXECUTABLE $$EXECUTABLE; \
+	done
+	zip -r flintc.zip $(RELEASE_EXECUTABLES) stdlib
+	rm $(RELEASE_EXECUTABLES)
 
 test: lint generate-mocks release
 	sed -i -e "s/ as / as! /g" .build/checkouts/Cuckoo/Source/Initialization/ThreadLocal.swift

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ Boogie_Z3_slink=boogie/Binaries/z3.exe
 Symbooglix_Z3_slink=symbooglix/src/SymbooglixDriver/bin/Release/z3.exe
 Z3_SYSTEM_PATH = $(shell which z3)
 RELEASE_EXECUTABLES=flintc flint-test flint-repl flint-ca flint-lsp
-BUILD_ARGS=
 .PHONY: all debug release zip test lint generate-sources generate-mocks test-nogen clean
 
 all: generate-sources $(BOOGIE_EXE) $(SYMBOOGLIX_EXE) debug

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,17 @@ Boogie_Z3_slink=boogie/Binaries/z3.exe
 Symbooglix_Z3_slink=symbooglix/src/SymbooglixDriver/bin/Release/z3.exe
 Z3_SYSTEM_PATH = $(shell which z3)
 RELEASE_EXECUTABLES=flintc flint-test flint-repl flint-ca flint-lsp
+BUILD_ARGS=
 .PHONY: all debug release zip test lint generate-sources generate-mocks test-nogen clean
 
 all: generate-sources $(BOOGIE_EXE) $(SYMBOOGLIX_EXE) debug
 
 debug: generate-sources
-	swift build
+	swift build $(BUILD_ARGS)
 	cp -r stdlib .build/debug/
 
 release: generate-sources $(BOOGIE_EXE) $(SYMBOOGLIX_EXE)
-	swift build -c release --static-swift-stdlib
+	swift build -c release $(BUILD_ARGS)
 	cp -r stdlib .build/release/
 
 xcode:

--- a/docs/language_guide.md
+++ b/docs/language_guide.md
@@ -171,6 +171,28 @@ bash <(curl -s https://raw.githubusercontent.com/flintlang/flint/master/utils/in
 
 Note that this script can be run from any directory, but will always install Flint in `~/.flint`.
 
+#### Makefile options
+The Makefile provides some options for you to customize your builds.
+
+##### `BUILD_ARGS`
+This option allows you to specify extra arguments for the `swift build` step.
+
+For example, the following command builds only the `flintc` executable, but not the rest.
+
+```bash
+BUILD_ARGS="--product flintc" make release
+```
+
+##### `ZIP_EXECUTABLES`
+This option allows you to specify which executables to include in the resulting zip file.
+If not set, the `make zip` target will try to include all Flint executables in the zip file by default.
+
+For example, the following command includes only `flintc` and `flint-repl` in the final zip file.
+
+```bash
+ZIP_EXECUTABLES="flintc flint-repl" make zip
+```
+
 ### Docker
 
 To use Flint in  a [Docker](https://www.docker.com/) container run the following: 


### PR DESCRIPTION
# Implementation Overview

- Pin swiftlint version in the travis config to fix the error during the linting stage
- Include all generated flint executables (e.g. flintc, flint-repl) by default when running `make zip`
- Updated node version from 11.x -> 13.x (11.x is no longer supported) on travis
- Added macOS target to travis config, so that macOS binaries can also be released alongside with linux binaries